### PR TITLE
feat(trackball): Macナチュラルスクロール対応のスクロール反転とカーソル補正を整理

### DIFF
--- a/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
+++ b/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
@@ -48,8 +48,8 @@
     trackball_listener: trackball_listener {
         compatible = "zmk,input-listener";
         device = <&trackball>;
-        /* Pointer系: ハードの向き補正として X を反転（スクロールとは別パイプライン） */
-        input-processors = <&zip_xy_transform (INPUT_TRANSFORM_X_INVERT)>;
+        /* Pointer系: ハードの向き補正として X と Y を反転（スクロールとは別パイプライン） */
+        input-processors = <&zip_xy_transform (INPUT_TRANSFORM_X_INVERT | INPUT_TRANSFORM_Y_INVERT)>;
         
         /* Scroll系 (Mac): Xのみ反転。ナチュラルスクロールON時に従来の体感へ */
         /* Mac用: ナチュラルスクロールON時 */

--- a/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
+++ b/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
@@ -51,10 +51,19 @@
         device = <&trackball>;
         input-processors = <&zip_xy_transform (INPUT_TRANSFORM_X_INVERT | INPUT_TRANSFORM_Y_INVERT)>;
         
-        scroller {
+        /* Mac用: ナチュラルスクロールON時 */
+        scroller_mac {
             layers = <5>;
-            input-processors = <&zip_xy_to_scroll_mapper>, <&zip_scroll_transform (INPUT_TRANSFORM_Y_INVERT)>, <&zip_scroll_scaler 1 128>;
+            input-processors = <&zip_xy_to_scroll_mapper>, <&zip_scroll_transform (INPUT_TRANSFORM_X_INVERT | INPUT_TRANSFORM_Y_INVERT)>, <&zip_scroll_scaler 1 128>;
             process-next;
+
+        /* Win用: TODO */
+        /* scroller_win {
+            layers = <ここにレイヤを指定>; /* TODO Win用スクロールレイヤを設定 */
+            input-processors = <&zip_xy_to_scroll_mapper>, <&zip_scroll_transform (INPUT_TRANSFORM_Y_INVERT)>, <&zip_scroll_scaler 1 128>;
+            process-nextt;
+        }; */
+
         };
     };
 };

--- a/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
+++ b/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
@@ -59,9 +59,9 @@
 
         /* Win用: TODO */
         /* scroller_win {
-            layers = <ここにレイヤを指定>; /* TODO Win用スクロールレイヤを設定 */
+            layers = <6>; // Win用スクロールレイヤを設定（必要に応じて変更）
             input-processors = <&zip_xy_to_scroll_mapper>, <&zip_scroll_transform (INPUT_TRANSFORM_Y_INVERT)>, <&zip_scroll_scaler 1 128>;
-            process-nextt;
+            process-next;
         }; */
 
         };

--- a/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
+++ b/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
@@ -1,4 +1,3 @@
-
 #include <dt-bindings/zmk/matrix_transform.h>
 #include <input/processors.dtsi>
 #include <dt-bindings/zmk/input_transform.h>
@@ -49,12 +48,14 @@
     trackball_listener: trackball_listener {
         compatible = "zmk,input-listener";
         device = <&trackball>;
-        input-processors = <&zip_xy_transform (INPUT_TRANSFORM_X_INVERT | INPUT_TRANSFORM_Y_INVERT)>;
+        /* Pointer系: 反転なし */
+        input-processors = <&zip_xy_transform (0)>;
         
+        /* Scroll系 (Mac): Xのみ反転。ナチュラルスクロールON時に従来の体感へ */
         /* Mac用: ナチュラルスクロールON時 */
         scroller_mac {
             layers = <5>;
-            input-processors = <&zip_xy_to_scroll_mapper>, <&zip_scroll_transform (INPUT_TRANSFORM_X_INVERT | INPUT_TRANSFORM_Y_INVERT)>, <&zip_scroll_scaler 1 128>;
+            input-processors = <&zip_xy_to_scroll_mapper>, <&zip_scroll_transform (INPUT_TRANSFORM_X_INVERT)>, <&zip_scroll_scaler 1 128>;
             process-next;
 
         /* Win用: TODO */
@@ -109,4 +110,3 @@
         wakeup-source;
     };
 };
-

--- a/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
+++ b/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
@@ -48,8 +48,8 @@
     trackball_listener: trackball_listener {
         compatible = "zmk,input-listener";
         device = <&trackball>;
-        /* Pointer系: 反転なし */
-        input-processors = <&zip_xy_transform (0)>;
+        /* Pointer系: ハードの向き補正として X を反転（スクロールとは別パイプライン） */
+        input-processors = <&zip_xy_transform (INPUT_TRANSFORM_X_INVERT)>;
         
         /* Scroll系 (Mac): Xのみ反転。ナチュラルスクロールON時に従来の体感へ */
         /* Mac用: ナチュラルスクロールON時 */

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -80,11 +80,11 @@
 
         Move {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_LEFT  &msc SCRL_RIGHT  &none     &none
+&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
 &mo 5             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &mo 5
 &mt LEFT_SHIFT Z  &mt LCTRL X  &mt LALT C      &mt LGUI V     &none      &kp TAB                              &kp ENTER    &none  &kp RCTRL       &kp RALT         &kp RGUI  &kp RSHIFT
-                                               &kp LCTRL      &kp LALT   &kp LCMD             &msc SCRL_UP    &kp RS(TAB)
-                                                              &moto 2 0  &moto 3 1            &msc SCRL_DOWN  &kp TAB
+                                               &kp LCTRL      &kp LALT   &kp LCMD             &msc SCRL_DOWN    &kp RS(TAB)
+                                                              &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
             >;
         };
 
@@ -120,11 +120,11 @@
 
         Scroll {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_LEFT  &msc SCRL_RIGHT  &none     &none
+&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
 &none             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &none
 &mt LEFT_SHIFT Z  &mt LCTRL X  &mt LALT C      &mt LGUI V     &none      &kp TAB                              &kp ENTER    &none  &kp RCTRL       &kp RALT         &kp RGUI  &kp RSHIFT
-                                               &kp LCTRL      &kp LALT   &kp LCMD             &msc SCRL_UP    &kp RS(TAB)
-                                                              &moto 2 0  &moto 3 1            &msc SCRL_DOWN  &kp TAB
+                                               &kp LCTRL      &kp LALT   &kp LCMD             &msc SCRL_DOWN    &kp RS(TAB)
+                                                              &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
             >;
         };
 


### PR DESCRIPTION
feat(trackball): Macナチュラルスクロール対応のスクロール反転とカーソル補正を整理

- Pointer系: ハードの都合でX/Y両軸を反転してカーソル移動を補正
- Scroll系 (Mac): ナチュラルスクロールON時に従来体感を維持するためX/Y両軸を反転
- 将来のWin用scrollerをコメントアウトで残し、可読性を改善