### PR TITLE
Fix module.yml structure for ZMK module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,5 +1,5 @@
 name: zmk_input_mode
 build:
   cmake: ..
-  settings:
-    board_root: .
+settings:
+  board_root: .


### PR DESCRIPTION
## Summary
- fix module yaml structure for zmk input mode module

## Testing
- `yamllint zephyr/module.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: cannot connect to proxy)*
- `python - <<'PY'
import yaml,sys
with open('zephyr/module.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY` *(fails: No module named 'yaml')*
- `pip install pyyaml` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a9830b392c832cbe483074d677b431