### PR TITLE
入力モード拡張をN状態に対応しビヘイビア追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,13 @@
 
 zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
 
-# Core and behaviors (minimal set: im_set, im_next, im_mo)
+# Core and behaviors
 target_sources(app PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/src/input_mode.c
   ${CMAKE_CURRENT_LIST_DIR}/src/behaviors/behavior_im_set.c
   ${CMAKE_CURRENT_LIST_DIR}/src/behaviors/behavior_im_next.c
   ${CMAKE_CURRENT_LIST_DIR}/src/behaviors/behavior_im_mo.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/behaviors/behavior_im_to.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/behaviors/behavior_im_tog.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/behaviors/behavior_im_kp.c
 )

--- a/boards/arm/akdk_bt1/Kconfig
+++ b/boards/arm/akdk_bt1/Kconfig
@@ -5,19 +5,20 @@ config BOARD_ENABLE_DCDC
     depends on BOARD_AKDK_BT1
 
 
-menu "Input Mode (two states: 0=macOS, 1=Windows)"
+menu "Input Mode"
 
 config IM_NUM_STATES
     int "Number of input modes"
     default 2
-    range 2 2
+    range 2 8
     help
-      最小導入では 2 状態に固定します（0=macOS, 1=Windows）。
+      入力モードの総数を設定します。0 から N-1 までの値を状態として扱い、
+      デフォルトでは 2 状態 (0=macOS, 1=Windows) ですが最大 8 まで増やせます。
 
 config IM_DEFAULT_STATE
-    int "Default input mode at boot (0=macOS)"
+    int "Default input mode at boot"
     default 0
-    range 0 1
+    range 0 (IM_NUM_STATES - 1)
 
 config IM_SETTINGS
     bool "Persist input mode via Zephyr settings"

--- a/dts/bindings/zmk,behavior-im-kp.yaml
+++ b/dts/bindings/zmk,behavior-im-kp.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+# Input Mode: key press based on current state
+
+description: |-
+  Send one of the given key codes depending on the current input mode.
+  Provide IM_NUM_STATES key codes.
+
+compatible: "zmk,behavior-im-kp"
+
+include: behavior.yaml
+
+# Up to eight parameters; only the first IM_NUM_STATES entries are used.
+#binding-cells:
+  - kc0
+  - kc1
+  - kc2
+  - kc3
+  - kc4
+  - kc5
+  - kc6
+  - kc7
+

--- a/dts/bindings/zmk,behavior-im-mo.yaml
+++ b/dts/bindings/zmk,behavior-im-mo.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+# Input Mode: momentarily activate layer based on current state
+
+description: |-
+  Momentarily activate one layer from the list depending on the current
+  input mode. Provide IM_NUM_STATES layer numbers.
+
+compatible: "zmk,behavior-im-mo"
+
+include: behavior.yaml
+
+# Up to eight parameters; only the first IM_NUM_STATES entries are used.
+#binding-cells:
+  - l0
+  - l1
+  - l2
+  - l3
+  - l4
+  - l5
+  - l6
+  - l7
+

--- a/dts/bindings/zmk,behavior-im-next.yaml
+++ b/dts/bindings/zmk,behavior-im-next.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Input Mode: advance to next state
+
+description: |-
+  Advance to the next input mode. Wraps back to 0 after the last mode.
+
+compatible: "zmk,behavior-im-next"
+
+include: behavior.yaml
+
+# No arguments required
+#binding-cells: 0
+

--- a/dts/bindings/zmk,behavior-im-set.yaml
+++ b/dts/bindings/zmk,behavior-im-set.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+# Input Mode: set to a specific state
+
+description: |-
+  Set the current input mode to the provided state index.
+
+compatible: "zmk,behavior-im-set"
+
+include: behavior.yaml
+
+# One argument: target state to set.
+#binding-cells:
+  - state
+

--- a/dts/bindings/zmk,behavior-im-to.yaml
+++ b/dts/bindings/zmk,behavior-im-to.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+# Input Mode: layer "to" based on current state
+
+description: |-
+  Switch to one of the given layers depending on the current input mode.
+  Provide IM_NUM_STATES layer numbers.
+
+compatible: "zmk,behavior-im-to"
+
+include: behavior.yaml
+
+# Up to eight parameters; only the first IM_NUM_STATES entries are used.
+#binding-cells:
+  - l0
+  - l1
+  - l2
+  - l3
+  - l4
+  - l5
+  - l6
+  - l7
+

--- a/dts/bindings/zmk,behavior-im-tog.yaml
+++ b/dts/bindings/zmk,behavior-im-tog.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+# Input Mode: toggle layer based on current state
+
+description: |-
+  Toggle one of the given layers depending on the current input mode.
+  Provide IM_NUM_STATES layer numbers.
+
+compatible: "zmk,behavior-im-tog"
+
+include: behavior.yaml
+
+# Up to eight parameters; only the first IM_NUM_STATES entries are used.
+#binding-cells:
+  - l0
+  - l1
+  - l2
+  - l3
+  - l4
+  - l5
+  - l6
+  - l7
+

--- a/include/input_mode.h
+++ b/include/input_mode.h
@@ -1,0 +1,29 @@
+#ifndef INPUT_MODE_H
+#define INPUT_MODE_H
+
+/*
+ * Input Mode core API
+ * --------------------
+ *  - im_get_state():   Get the current input mode (0..N-1)
+ *  - im_set_state(s):  Set the current input mode to s
+ *  - im_next_state():  Advance to the next input mode
+ *  - im_num_states():  Compile-time number of modes
+ *
+ * Behaviors pass multiple parameters; im_param_at() is a small helper to
+ * fetch the Nth parameter from a behavior binding.
+ */
+
+#include <stdint.h>
+#include <zmk/behavior.h>
+
+uint8_t im_get_state(void);
+int im_set_state(uint8_t state);
+int im_next_state(void);
+static inline uint8_t im_num_states(void) { return CONFIG_IM_NUM_STATES; }
+
+static inline uint32_t im_param_at(const struct zmk_behavior_binding *b, uint8_t idx) {
+    const uint32_t *params = &b->param1;
+    return params[idx];
+}
+
+#endif /* INPUT_MODE_H */

--- a/src/behaviors/behavior_im_kp.c
+++ b/src/behaviors/behavior_im_kp.c
@@ -1,0 +1,46 @@
+// &im_kp <KC0 KC1 ...>
+// --------------------
+// Emit a keycode depending on current input mode. The keycode pressed is
+// remembered per key position to ensure proper release even if the mode
+// changes while the key is held.
+
+#include <zephyr/kernel.h>
+#include <drivers/behavior.h>
+#include <zmk/hid.h>
+#include <zmk/keymap.h>
+
+#include "input_mode.h"
+
+#ifndef ZMK_KEYMAP_LEN_MAX
+#define ZMK_KEYMAP_LEN_MAX 160
+#endif
+
+static uint32_t pressed_kc[ZMK_KEYMAP_LEN_MAX];
+
+static int im_kp_pressed(struct zmk_behavior_binding *binding,
+                         struct zmk_behavior_binding_event event) {
+    uint8_t s = im_get_state();
+    if (s >= im_num_states()) {
+        return -EINVAL;
+    }
+    uint32_t kc = im_param_at(binding, s);
+    pressed_kc[event.position] = kc;
+    zmk_hid_keyboard_press(kc);
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int im_kp_released(struct zmk_behavior_binding *binding,
+                          struct zmk_behavior_binding_event event) {
+    zmk_hid_keyboard_release(pressed_kc[event.position]);
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api im_kp_driver_api = {
+    .binding_pressed = im_kp_pressed,
+    .binding_released = im_kp_released,
+};
+
+BEHAVIOR_DT_INST_DEFINE(0, im_kp, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &im_kp_driver_api);
+

--- a/src/behaviors/behavior_im_mo.c
+++ b/src/behaviors/behavior_im_mo.c
@@ -1,0 +1,47 @@
+// &im_mo <L0 L1 ...>
+// -------------------
+// Momentarily activate layer Ls while held, where s is current input mode.
+// The activated layer is tracked per key position to ensure proper release
+// even if the mode changes while the key is held.
+
+#include <zephyr/kernel.h>
+#include <drivers/behavior.h>
+#include <zmk/layers.h>
+#include <zmk/keymap.h>
+
+#include "input_mode.h"
+
+#ifndef ZMK_KEYMAP_LEN_MAX
+#define ZMK_KEYMAP_LEN_MAX 160
+#endif
+
+static uint8_t pressed_layer[ZMK_KEYMAP_LEN_MAX];
+
+static int im_mo_pressed(struct zmk_behavior_binding *binding,
+                         struct zmk_behavior_binding_event event) {
+    uint8_t s = im_get_state();
+    if (s >= im_num_states()) {
+        return -EINVAL;
+    }
+    uint32_t layer = im_param_at(binding, s);
+    zmk_layer_activate(layer);
+    pressed_layer[event.position] = layer;
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int im_mo_released(struct zmk_behavior_binding *binding,
+                          struct zmk_behavior_binding_event event) {
+    uint8_t layer = pressed_layer[event.position];
+    zmk_layer_deactivate(layer);
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api im_mo_driver_api = {
+    .binding_pressed = im_mo_pressed,
+    .binding_released = im_mo_released,
+};
+
+BEHAVIOR_DT_INST_DEFINE(0, im_mo, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &im_mo_driver_api);
+

--- a/src/behaviors/behavior_im_next.c
+++ b/src/behaviors/behavior_im_next.c
@@ -1,0 +1,22 @@
+// &im_next
+// --------
+// Cycle to the next input mode.
+
+#include <zephyr/kernel.h>
+#include <drivers/behavior.h>
+
+#include "input_mode.h"
+
+static int im_next_pressed(struct zmk_behavior_binding *binding,
+                           struct zmk_behavior_binding_event event) {
+    return im_next_state();
+}
+
+static const struct behavior_driver_api im_next_driver_api = {
+    .binding_pressed = im_next_pressed,
+};
+
+BEHAVIOR_DT_INST_DEFINE(0, im_next, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &im_next_driver_api);
+

--- a/src/behaviors/behavior_im_set.c
+++ b/src/behaviors/behavior_im_set.c
@@ -1,0 +1,22 @@
+// &im_set <state>
+// -----------------
+// Set the current input mode to the specified state.
+
+#include <zephyr/kernel.h>
+#include <drivers/behavior.h>
+
+#include "input_mode.h"
+
+static int im_set_pressed(struct zmk_behavior_binding *binding,
+                          struct zmk_behavior_binding_event event) {
+    return im_set_state(binding->param1);
+}
+
+static const struct behavior_driver_api im_set_driver_api = {
+    .binding_pressed = im_set_pressed,
+};
+
+BEHAVIOR_DT_INST_DEFINE(0, im_set, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &im_set_driver_api);
+

--- a/src/behaviors/behavior_im_to.c
+++ b/src/behaviors/behavior_im_to.c
@@ -1,0 +1,28 @@
+// &im_to <L0 L1 ...>
+// ------------------
+// Jump to layer Ls depending on current input mode.
+
+#include <zephyr/kernel.h>
+#include <drivers/behavior.h>
+#include <zmk/layers.h>
+
+#include "input_mode.h"
+
+static int im_to_pressed(struct zmk_behavior_binding *binding,
+                         struct zmk_behavior_binding_event event) {
+    uint8_t s = im_get_state();
+    if (s >= im_num_states()) {
+        return -EINVAL;
+    }
+    zmk_layer_to(im_param_at(binding, s));
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api im_to_driver_api = {
+    .binding_pressed = im_to_pressed,
+};
+
+BEHAVIOR_DT_INST_DEFINE(0, im_to, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &im_to_driver_api);
+

--- a/src/behaviors/behavior_im_tog.c
+++ b/src/behaviors/behavior_im_tog.c
@@ -1,0 +1,28 @@
+// &im_tog <L0 L1 ...>
+// -------------------
+// Toggle layer Ls depending on current input mode.
+
+#include <zephyr/kernel.h>
+#include <drivers/behavior.h>
+#include <zmk/layers.h>
+
+#include "input_mode.h"
+
+static int im_tog_pressed(struct zmk_behavior_binding *binding,
+                          struct zmk_behavior_binding_event event) {
+    uint8_t s = im_get_state();
+    if (s >= im_num_states()) {
+        return -EINVAL;
+    }
+    zmk_layer_toggle(im_param_at(binding, s));
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api im_tog_driver_api = {
+    .binding_pressed = im_tog_pressed,
+};
+
+BEHAVIOR_DT_INST_DEFINE(0, im_tog, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &im_tog_driver_api);
+

--- a/src/input_mode.c
+++ b/src/input_mode.c
@@ -1,0 +1,74 @@
+// Input Mode core implementation
+// -------------------------------
+// Maintains a device-wide input mode state (0..N-1) with optional persistence
+// via Zephyr settings. Future split support can hook synchronization where
+// indicated below.
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/settings/settings.h>
+#include <string.h>
+
+#include "input_mode.h"
+
+static uint8_t current_state = CONFIG_IM_DEFAULT_STATE;
+
+static int save_state(void) {
+    if (!IS_ENABLED(CONFIG_IM_SETTINGS)) {
+        return 0;
+    }
+    return settings_save_one("im/state", &current_state, sizeof(current_state));
+}
+
+uint8_t im_get_state(void) {
+    return current_state;
+}
+
+int im_set_state(uint8_t state) {
+    if (state >= CONFIG_IM_NUM_STATES) {
+        return -EINVAL;
+    }
+    current_state = state;
+    // TODO: future split sync hook goes here
+    return save_state();
+}
+
+int im_next_state(void) {
+    uint8_t next = current_state + 1;
+    if (next >= CONFIG_IM_NUM_STATES) {
+        next = 0;
+    }
+    return im_set_state(next);
+}
+
+static int im_settings_set(const char *name, size_t len,
+                           settings_read_cb read_cb, void *cb_arg) {
+    if (!strncmp(name, "state", len)) {
+        uint8_t state;
+        if (read_cb(cb_arg, &state, sizeof(state)) == sizeof(state)) {
+            if (state < CONFIG_IM_NUM_STATES) {
+                current_state = state;
+            }
+        }
+        return 0;
+    }
+    return -ENOENT;
+}
+
+static struct settings_handler im_conf = {
+    .name = "im",
+    .h_set = im_settings_set,
+};
+
+static int im_init(const struct device *dev) {
+    ARG_UNUSED(dev);
+    if (IS_ENABLED(CONFIG_IM_SETTINGS)) {
+        settings_subsys_init();
+        settings_register(&im_conf);
+        settings_load_subtree("im");
+    }
+    return 0;
+}
+
+SYS_INIT(im_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,5 +1,5 @@
 name: zmk_input_mode
 build:
-  cmake: ..
+  cmake: .
   settings:
     board_root: .


### PR DESCRIPTION
## 概要
- 入力モードの状態数をKconfigで最大8まで設定可能にし、デフォルト値範囲を調整
- 入力モードAPIと設定保存処理を実装し、現在のモードを取得・変更・循環可能に
- モード依存でレイヤ切替やキー出力を行う `im_mo` `im_to` `im_tog` `im_kp` を追加
- 各ビヘイビア用のDevicetreeバインディングを用意し、IM_NUM_STATES個の引数に対応

## テスト
- `west build -s zmk/app -d /tmp/tmp.build -b akdk_bt1 -S studio-rpc-usb-uart -- -DZMK_CONFIG=/tmp/zmk-config/config -DSHIELD=surround1x0_akdk_left -DZMK_EXTRA_MODULES=$(pwd) -DCONFIG_ZMK_STUDIO=y` *(command not found: west)*
- `pip install --user west` *(Tunnel connection failed: 403 Forbidden)*
- `yamllint dts/bindings/zmk,behavior-im-mo.yaml` *(command not found: yamllint)*
- `pip install yamllint` *(Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9830b392c832cbe483074d677b431