### PR TITLE
Mac/Winレイアウトシフト用ビヘイビアの追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.20.5)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(zmk-layout-shift)
+
+if(CONFIG_LAYOUT_SHIFT)
+  if ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    target_sources_ifdef(CONFIG_LAYOUT_SHIFT app PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_key_press.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_toggle.c
+    )
+  endif()
+endif()

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,43 @@
+# zmk-layout-shift Kconfig
+
+config LAYOUT_SHIFT
+    bool "Layout Shift"
+    default y
+    help
+      Enable the Layout Shift module.
+
+if LAYOUT_SHIFT
+
+choice LAYOUT_SHIFT_TARGET_LAYOUT
+    prompt "Target keyboard layout"
+    default LAYOUT_SHIFT_TARGET_JIS
+    help
+      Select the target keyboard layout for layout shift mappings.
+      This determines which key mappings are used when layout shift is active.
+
+config LAYOUT_SHIFT_TARGET_JIS
+    bool "Japanese (JIS)"
+    help
+      Japanese keyboard layout mappings.
+
+config LAYOUT_SHIFT_TARGET_DVORAK
+    bool "Dvorak"
+    help
+      Dvorak keyboard layout mappings.
+
+config LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
+    bool "Swap Ctrl and Cmd"
+    help
+      Swap Ctrl / Cmd for Windows / Mac.
+
+endchoice
+
+config LAYOUT_SHIFT_PERSISTENT_STATE
+    bool "Layout Shift Persistent State"
+    default y
+    select SETTINGS
+    help
+      Enable persistent storage of layout shift state across reboots.
+      This feature requires CONFIG_SETTINGS to be enabled.
+
+endif

--- a/dts/bindings/behaviors/zmk,behavior-layout-shift-key-press.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-shift-key-press.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout shift custom key press behavior that maps keycodes according to the current layout shift state
+
+compatible: "zmk,behavior-layout-shift-key-press"
+
+include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-layout-shift-toggle.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-shift-toggle.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout shift toggle behavior
+
+compatible: "zmk,behavior-layout-shift-toggle"
+
+include: zero_param.yaml
+
+properties:
+  toggle-mode:
+    type: string
+    required: false
+    default: "flip"
+    enum:
+      - "on"
+      - "off" 
+      - "flip"
+    description: |
+      Toggle mode for the layout shift behavior:
+      - "on": Turn layout shift on
+      - "off": Turn layout shift off
+      - "flip": Toggle layout shift state

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* ZMK Layout Shift Module */
+
+#include <dt-bindings/zmk/keys.h>
+
+/ {
+    behaviors {
+        // Layout-aware key press behavior alias
+        kpls: layout_shift_key_press {
+            compatible = "zmk,behavior-layout-shift-key-press";
+            #binding-cells = <1>;
+            label = "LAYOUT_SHIFT_KEY_PRESS";
+            display-name = "Key Press with Layout Shift";
+        };
+
+        // Layout-aware mod-tap behavior alias
+        mtls: layout_shift_mod_tap {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "hold-preferred";
+            tapping-term-ms = <200>;
+            bindings = <&kpls>, <&kpls>;
+            display-name = "Mod-Tap with Layout Shift";
+        };
+
+        // Layout shift toggle behaviors
+        tog_ls: toggle_layout_shift {
+            compatible = "zmk,behavior-layout-shift-toggle";
+            #binding-cells = <0>;
+            toggle-mode = "flip";
+            label = "LAYOUT_SHIFT_TOGGLE";
+            display-name = "Toggle Layout Shift";
+        };
+
+        tog_ls_on: toggle_layout_shift_on {
+            compatible = "zmk,behavior-layout-shift-toggle";
+            #binding-cells = <0>;
+            toggle-mode = "on";
+            label = "LAYOUT_SHIFT_TOGGLE_ON";
+            display-name = "Toggle Layout Shift On";
+        };
+
+        tog_ls_off: toggle_layout_shift_off {
+            compatible = "zmk,behavior-layout-shift-toggle";
+            #binding-cells = <0>;
+            toggle-mode = "off";
+            label = "LAYOUT_SHIFT_TOGGLE_OFF";
+            display-name = "Toggle Layout Shift Off";
+        };
+    };
+};

--- a/dts/layout_shift_kp_override.dtsi
+++ b/dts/layout_shift_kp_override.dtsi
@@ -1,0 +1,22 @@
+// Layout Shift Overlay - Replaces &kp behavior with custom implementation
+// This file should be included in keyboard config to override &kp behavior
+
+#include "layout_shift.dtsi"
+
+/ {
+    behaviors {
+        // Keep the original key_press behavior for ZMK core components
+        original_key_press: original_key_press {
+            compatible = "zmk,behavior-key-press";
+            #binding-cells = <1>;
+            label = "KEY_PRESS";
+        };
+
+        // Override the existing &kp behavior to use our custom implementation
+        kp: key_press {
+            compatible = "zmk,behavior-layout-shift-key-press";
+            #binding-cells = <1>;
+            label = "LAYOUT_SHIFT_KEY_PRESS";
+        };
+    };
+};

--- a/src/behavior_layout_shift_key_press.c
+++ b/src/behavior_layout_shift_key_press.c
@@ -1,0 +1,323 @@
+#define DT_DRV_COMPAT zmk_behavior_layout_shift_key_press
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <drivers/behavior.h>
+#include <zmk/behavior.h>
+#include <zmk/event_manager.h>
+#include <zmk/events/keycode_state_changed.h>
+#include <zmk/hid.h>
+#include <zmk/keys.h>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/modifiers.h>
+#include <dt-bindings/zmk/hid_usage.h>
+#include <dt-bindings/zmk/hid_usage_pages.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+// External function to check layout shift state
+extern bool zmk_layout_shift_is_active(void);
+
+// Keycode mapping structure
+struct keycode_mapping {
+    uint32_t us_keycode;
+    uint32_t target_keycode;
+    zmk_mod_flags_t optional_modifiers;  // Bitmask of modifiers that are optional during matching
+};
+
+// Convenient modifier mask definitions (defined before including layouts)
+#define OPTIONAL_SHIFT  (MOD_LSFT | MOD_RSFT)
+#define OPTIONAL_CTRL   (MOD_LCTL | MOD_RCTL)
+#define OPTIONAL_ALT    (MOD_LALT | MOD_RALT)
+#define OPTIONAL_GUI    (MOD_LGUI | MOD_RGUI)
+#define OPTIONAL_ALL    (0xFF)
+#define OPTIONAL_NONE   (0)
+
+// Include all layout definitions (with conditional compilation)
+#include "layouts/index.h"
+
+#define LAYOUT_MAP_SIZE (sizeof(layout_map) / sizeof(layout_map[0]))
+
+
+// Function to lookup mapped keycode from input keycode with optional modifier support
+// Returns the mapped keycode, and optionally stores the matched layout entry index
+static uint32_t lookup_mapped_keycode(uint32_t input_keycode, int *matched_index) {
+    // Only apply mapping if layout shift is active
+    if (!zmk_layout_shift_is_active()) {
+        return input_keycode;
+    }
+
+    // Get current explicit modifier state and any modifiers embedded in the keycode
+    zmk_mod_flags_t current_mods = zmk_hid_get_explicit_mods();
+    zmk_mod_flags_t keycode_mods = SELECT_MODS(input_keycode);
+
+    // Combine explicit modifiers with modifiers from the keycode
+    zmk_mod_flags_t total_input_mods = current_mods | keycode_mods;
+
+    // Get the base keycode without modifiers for comparison
+    uint32_t base_input = STRIP_MODS(input_keycode);
+
+    // Look up in mapping table with optional modifier support
+    for (size_t i = 0; i < LAYOUT_MAP_SIZE; i++) {
+        uint32_t base_us = STRIP_MODS(layout_map[i].us_keycode);
+        zmk_mod_flags_t us_mods = SELECT_MODS(layout_map[i].us_keycode);
+
+        // Check if base keycodes match
+        if (base_input == base_us) {
+            // Check if non-optional modifiers match
+            zmk_mod_flags_t required_mods = us_mods & ~layout_map[i].optional_modifiers;
+            zmk_mod_flags_t input_required_mods = total_input_mods & ~layout_map[i].optional_modifiers;
+
+            if (required_mods == input_required_mods) {
+                // Match found! Apply target keycode with layout-defined modifiers
+                uint32_t target_base = STRIP_MODS(layout_map[i].target_keycode);
+                zmk_mod_flags_t target_mods = SELECT_MODS(layout_map[i].target_keycode);
+
+                // Combine target modifiers with non-optional input modifiers
+                zmk_mod_flags_t final_mods = target_mods | (total_input_mods & layout_map[i].optional_modifiers);
+
+                uint32_t result = (final_mods != 0) ? APPLY_MODS(final_mods, target_base) : target_base;
+
+                // Store the matched index if caller wants it
+                if (matched_index != NULL) {
+                    *matched_index = i;
+                }
+
+                LOG_DBG("LAYOUT_SHIFT: Mapping %08X -> %08X (input_mods: %02X, required: %02X, target_mods: %02X, final: %02X)",
+                        input_keycode, result, total_input_mods, required_mods, target_mods, final_mods);
+                return result;
+            }
+        }
+    }
+
+    // If no mapping found, return original keycode
+    if (matched_index != NULL) {
+        *matched_index = -1;  // Indicate no match found
+    }
+    LOG_DBG("LAYOUT_SHIFT: No mapping found for %08X", input_keycode);
+    return input_keycode;
+}
+
+// Storage for tracking key press/release mappings
+#define MAX_PRESSED_KEYS 16
+
+struct key_mapping_entry {
+    uint32_t original_keycode;
+    uint32_t mapped_keycode;
+    bool active;
+};
+
+struct behavior_layout_shift_key_press_data {
+    struct key_mapping_entry pressed_keys[MAX_PRESSED_KEYS];
+    zmk_mod_flags_t currently_masked_mods;
+};
+
+struct behavior_layout_shift_key_press_config {};
+
+// Helper function to mask unwanted modifiers
+static void mask_unwanted_modifiers(struct behavior_layout_shift_key_press_data *data,
+                                   zmk_mod_flags_t optional_mods, zmk_mod_flags_t mapped_keycode,
+                                   zmk_mod_flags_t current_mods) {
+    // Get modifiers that are defined in the mapped keycode
+    zmk_mod_flags_t mapped_mods = SELECT_MODS(mapped_keycode);
+
+    // Calculate unwanted modifiers:
+    // - NOT in optional_modifiers (required modifiers)
+    // - NOT in mapped_keycode modifiers (not needed for output)
+    // - BUT in current explicit modifiers (currently active)
+    zmk_mod_flags_t required_mods = ~optional_mods;  // Modifiers that are NOT optional
+    zmk_mod_flags_t not_needed_mods = ~mapped_mods;  // Modifiers NOT in mapped keycode
+    zmk_mod_flags_t unwanted_mods = required_mods & not_needed_mods & current_mods;
+
+    if (unwanted_mods != 0 && unwanted_mods != data->currently_masked_mods) {
+        // Clear any previously masked modifiers
+        if (data->currently_masked_mods != 0) {
+            zmk_hid_masked_modifiers_clear();
+        }
+
+        // Apply new modifier mask
+        zmk_hid_masked_modifiers_set(unwanted_mods);
+        data->currently_masked_mods = unwanted_mods;
+
+        LOG_DBG("LAYOUT_SHIFT: Masking unwanted modifiers: %02X (optional: %02X, mapped: %02X, current: %02X)",
+                unwanted_mods, optional_mods, mapped_mods, current_mods);
+    }
+}
+
+// Helper function to clear modifier mask
+static void clear_modifier_mask(struct behavior_layout_shift_key_press_data *data) {
+    if (data->currently_masked_mods != 0) {
+        zmk_hid_masked_modifiers_clear();
+        LOG_DBG("LAYOUT_SHIFT: Cleared modifier mask: %02X", data->currently_masked_mods);
+        data->currently_masked_mods = 0;
+    }
+}
+
+// Helper functions for key mapping storage
+static int store_key_mapping(struct behavior_layout_shift_key_press_data *data,
+                            uint32_t original_keycode, uint32_t mapped_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (!data->pressed_keys[i].active) {
+            data->pressed_keys[i].original_keycode = original_keycode;
+            data->pressed_keys[i].mapped_keycode = mapped_keycode;
+            data->pressed_keys[i].active = true;
+            return 0;
+        }
+    }
+    LOG_WRN("LAYOUT_SHIFT: No free slots to store key mapping");
+    return -ENOMEM;
+}
+
+static uint32_t get_stored_mapping(struct behavior_layout_shift_key_press_data *data,
+                                  uint32_t original_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (data->pressed_keys[i].active &&
+            data->pressed_keys[i].original_keycode == original_keycode) {
+            return data->pressed_keys[i].mapped_keycode;
+        }
+    }
+    return 0; // Not found
+}
+
+static int remove_key_mapping(struct behavior_layout_shift_key_press_data *data,
+                             uint32_t original_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (data->pressed_keys[i].active &&
+            data->pressed_keys[i].original_keycode == original_keycode) {
+            data->pressed_keys[i].active = false;
+            return 0;
+        }
+    }
+    return -ENOENT;
+}
+
+static int on_layout_shift_key_press_binding_pressed(struct zmk_behavior_binding *binding,
+                                                    struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    struct behavior_layout_shift_key_press_data *data = dev->data;
+
+    uint32_t original_keycode = binding->param1;
+    int matched_layout_index = -1;
+    uint32_t mapped_keycode = lookup_mapped_keycode(original_keycode, &matched_layout_index);
+
+    LOG_DBG("LAYOUT_SHIFT: Input keycode 0x%08X -> Mapped keycode 0x%08X", original_keycode, mapped_keycode);
+
+    // If layout shift is active and mapping occurred, handle unwanted modifier masking
+    if (zmk_layout_shift_is_active() && mapped_keycode != original_keycode && matched_layout_index >= 0) {
+        zmk_mod_flags_t current_mods = zmk_hid_get_explicit_mods();
+        zmk_mod_flags_t keycode_mods = SELECT_MODS(original_keycode);
+        zmk_mod_flags_t total_mods = current_mods | keycode_mods;
+
+        // Use the already found layout entry
+        mask_unwanted_modifiers(data, layout_map[matched_layout_index].optional_modifiers, mapped_keycode, total_mods);
+    }
+
+    // Store the mapping for use during release
+    int ret = store_key_mapping(data, original_keycode, mapped_keycode);
+    if (ret < 0) {
+        LOG_ERR("LAYOUT_SHIFT: Failed to store key mapping: %d", ret);
+    }
+
+    // Raise the mapped keycode event
+    return raise_zmk_keycode_state_changed_from_encoded(
+        mapped_keycode,
+        true,  // pressed
+        event.timestamp
+    );
+}
+
+static int on_layout_shift_key_press_binding_released(struct zmk_behavior_binding *binding,
+                                                     struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    struct behavior_layout_shift_key_press_data *data = dev->data;
+
+    uint32_t original_keycode = binding->param1;
+    uint32_t mapped_keycode;
+
+    // Try to get the stored mapping first
+    uint32_t stored_mapping = get_stored_mapping(data, original_keycode);
+    if (stored_mapping != 0) {
+        mapped_keycode = stored_mapping;
+        LOG_DBG("LAYOUT_SHIFT: Using stored mapping for release 0x%08X -> 0x%08X",
+                original_keycode, mapped_keycode);
+
+        // Remove the mapping from storage
+        remove_key_mapping(data, original_keycode);
+    } else {
+        // Fall back to recalculating if no stored mapping found
+        mapped_keycode = lookup_mapped_keycode(original_keycode, NULL);
+        LOG_DBG("LAYOUT_SHIFT: No stored mapping found, recalculating 0x%08X -> 0x%08X",
+                original_keycode, mapped_keycode);
+    }
+
+    LOG_DBG("LAYOUT_SHIFT: Released input keycode 0x%08X -> Mapped keycode 0x%08X", original_keycode, mapped_keycode);
+
+    // Clear modifier mask when key is released
+    // This ensures that modifier masking is only active while layout-shifted keys are pressed
+    clear_modifier_mask(data);
+
+    // Release the mapped keycode
+    return raise_zmk_keycode_state_changed_from_encoded(
+        mapped_keycode,
+        false, // released
+        event.timestamp
+    );
+}
+
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+static const struct behavior_parameter_value_metadata keycode_value_metadata[] = {
+    {
+        .display_name = "Keycode",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_HID_USAGE,
+    },
+};
+
+static const struct behavior_parameter_metadata_set keycode_parameter_set = {
+    .param1_values = keycode_value_metadata,
+    .param1_values_len = ARRAY_SIZE(keycode_value_metadata),
+};
+
+static const struct behavior_parameter_metadata_set metadata_sets[] = {keycode_parameter_set};
+
+static const struct behavior_parameter_metadata layout_shift_key_press_parameter_metadata = {
+    .sets_len = ARRAY_SIZE(metadata_sets),
+    .sets = metadata_sets,
+};
+#endif
+
+static const struct behavior_driver_api behavior_layout_shift_key_press_driver_api = {
+    .binding_pressed = on_layout_shift_key_press_binding_pressed,
+    .binding_released = on_layout_shift_key_press_binding_released,
+    .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .parameter_metadata = &layout_shift_key_press_parameter_metadata,
+#endif
+};
+
+static int layout_shift_key_press_init(const struct device *dev) {
+    struct behavior_layout_shift_key_press_data *data =
+        (struct behavior_layout_shift_key_press_data *)dev->data;
+
+    // Initialize the pressed keys storage
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        data->pressed_keys[i].active = false;
+    }
+
+    // Initialize modifier masking state
+    data->currently_masked_mods = 0;
+
+    LOG_INF("Layout Shift Behavior Initialized");
+    return 0;
+}
+
+// Define behavior instance only if devicetree node exists
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+static struct behavior_layout_shift_key_press_data behavior_layout_shift_key_press_data_0 = {};
+static const struct behavior_layout_shift_key_press_config behavior_layout_shift_key_press_config_0 = {};
+
+BEHAVIOR_DT_INST_DEFINE(0, layout_shift_key_press_init, NULL,
+                        &behavior_layout_shift_key_press_data_0, &behavior_layout_shift_key_press_config_0,
+                        POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_layout_shift_key_press_driver_api);
+#endif

--- a/src/behavior_layout_shift_toggle.c
+++ b/src/behavior_layout_shift_toggle.c
@@ -1,0 +1,143 @@
+#define DT_DRV_COMPAT zmk_behavior_layout_shift_toggle
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
+#include <string.h>
+#include <drivers/behavior.h>
+#include <zmk/behavior.h>
+#include <zmk/event_manager.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+enum toggle_mode {
+    TOGGLE_MODE_ON,
+    TOGGLE_MODE_OFF,
+    TOGGLE_MODE_FLIP
+};
+
+struct behavior_layout_shift_toggle_config {
+    enum toggle_mode toggle_mode;
+};
+
+struct behavior_layout_shift_toggle_data {};
+
+// Global layout shift state
+static bool layout_shift_active = false;
+
+#if IS_ENABLED(CONFIG_LAYOUT_SHIFT_PERSISTENT_STATE)
+static void layout_shift_save_work_handler(struct k_work *work) {
+    settings_save_one("layout_shift/state", &layout_shift_active, sizeof(layout_shift_active));
+    LOG_DBG("Saved layout shift state: %d", layout_shift_active);
+}
+
+static struct k_work_delayable layout_shift_save_work;
+
+static int layout_shift_settings_load_cb(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg) {
+    const char *next;
+    if (settings_name_steq(name, "state", &next) && !next) {
+        if (len != sizeof(layout_shift_active)) {
+            return -EINVAL;
+        }
+
+        int rc = read_cb(cb_arg, &layout_shift_active, sizeof(layout_shift_active));
+        if (rc >= 0) {
+            LOG_INF("Loaded layout shift state: %d", layout_shift_active);
+        }
+        return MIN(rc, 0);
+    }
+    return -ENOENT;
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(layout_shift, "layout_shift", NULL, layout_shift_settings_load_cb, NULL, NULL);
+#endif // IS_ENABLED(CONFIG_LAYOUT_SHIFT_PERSISTENT_STATE)
+
+// Function to get current layout shift state
+bool zmk_layout_shift_is_active(void) {
+    return layout_shift_active;
+}
+
+// Function to set layout shift state
+void zmk_layout_shift_set_active(bool active) {
+    if (layout_shift_active != active) {
+        layout_shift_active = active;
+        LOG_INF("Layout shift %s", active ? "activated" : "deactivated");
+        
+#if IS_ENABLED(CONFIG_LAYOUT_SHIFT_PERSISTENT_STATE)
+        // Debounce saving to flash to reduce wear
+        k_work_reschedule(&layout_shift_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
+#endif
+    }
+}
+
+// Function to toggle layout shift state
+void zmk_layout_shift_toggle(void) {
+    zmk_layout_shift_set_active(!layout_shift_active);
+}
+
+static int on_layout_shift_toggle_binding_pressed(struct zmk_behavior_binding *binding,
+                                                 struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    const struct behavior_layout_shift_toggle_config *config = dev->config;
+
+    switch (config->toggle_mode) {
+        case TOGGLE_MODE_ON:
+            zmk_layout_shift_set_active(true);
+            break;
+        case TOGGLE_MODE_OFF:
+            zmk_layout_shift_set_active(false);
+            break;
+        case TOGGLE_MODE_FLIP:
+            zmk_layout_shift_toggle();
+            break;
+    }
+
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int on_layout_shift_toggle_binding_released(struct zmk_behavior_binding *binding,
+                                                  struct zmk_behavior_binding_event event) {
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api behavior_layout_shift_toggle_driver_api = {
+    .binding_pressed = on_layout_shift_toggle_binding_pressed,
+    .binding_released = on_layout_shift_toggle_binding_released,
+    .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .get_parameter_metadata = zmk_behavior_get_empty_param_metadata,
+#endif
+};
+
+static int layout_shift_toggle_init(const struct device *dev) {
+    layout_shift_active = false;
+    
+#if IS_ENABLED(CONFIG_LAYOUT_SHIFT_PERSISTENT_STATE)
+    k_work_init_delayable(&layout_shift_save_work, layout_shift_save_work_handler);
+#endif
+    
+    LOG_INF("Layout Shift Toggle Behavior Initialized!");
+    return 0;
+}
+
+#define TOGGLE_MODE_FROM_STR(str) \
+    (strcmp(str, "on") == 0 ? TOGGLE_MODE_ON : \
+     strcmp(str, "off") == 0 ? TOGGLE_MODE_OFF : \
+     TOGGLE_MODE_FLIP)
+
+// Only define behavior instances if devicetree nodes exist
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define LAYOUT_SHIFT_TOGGLE_INST(n) \
+    static struct behavior_layout_shift_toggle_data behavior_layout_shift_toggle_data_##n = {}; \
+    static const struct behavior_layout_shift_toggle_config behavior_layout_shift_toggle_config_##n = { \
+        .toggle_mode = TOGGLE_MODE_FROM_STR(DT_INST_PROP_OR(n, toggle_mode, "flip")), \
+    }; \
+    BEHAVIOR_DT_INST_DEFINE(n, layout_shift_toggle_init, NULL, \
+                            &behavior_layout_shift_toggle_data_##n, \
+                            &behavior_layout_shift_toggle_config_##n, \
+                            POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, \
+                            &behavior_layout_shift_toggle_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(LAYOUT_SHIFT_TOGGLE_INST)
+#endif

--- a/src/layouts/index.h
+++ b/src/layouts/index.h
@@ -1,0 +1,11 @@
+// Layout index - includes all available layout definitions
+// Each layout file contains its own conditional compilation directives
+
+#include "layout_jis.h"
+#include "layout_dvorak.h"
+#include "layout_swap_ctrl_cmd.h"
+
+// Ensure at least one layout is defined
+#ifndef LAYOUT_DEFINED
+#error "No target layout selected. Please select a layout in Kconfig."
+#endif

--- a/src/layouts/layout_dvorak.h
+++ b/src/layouts/layout_dvorak.h
@@ -1,0 +1,42 @@
+#ifdef CONFIG_LAYOUT_SHIFT_TARGET_DVORAK
+#define LAYOUT_DEFINED
+// Dvorak keyboard layout mappings
+// Maps US QWERTY keycodes to their Dvorak equivalents
+static const struct keycode_mapping layout_map[] = {
+    /* Letter and symbol position changes (QWERTY -> Dvorak) */
+    /* For Dvorak, most modifiers are optional since it's primarily about key position changes */
+    {MINUS, LEFT_BRACKET, OPTIONAL_ALL},    // - -> [ (all modifiers optional)
+    {EQUAL, RIGHT_BRACKET, OPTIONAL_ALL},   // = -> ] (all modifiers optional)
+    {Q, SINGLE_QUOTE, OPTIONAL_ALL},        // Q -> ' (all modifiers optional)
+    {W, COMMA, OPTIONAL_ALL},               // W -> , (all modifiers optional)
+    {E, DOT, OPTIONAL_ALL},                 // E -> . (all modifiers optional)
+    {R, P, OPTIONAL_ALL},                   // R -> P (all modifiers optional)
+    {T, Y, OPTIONAL_ALL},                   // T -> Y (all modifiers optional)
+    {Y, F, OPTIONAL_ALL},                   // Y -> F (all modifiers optional)
+    {U, G, OPTIONAL_ALL},                   // U -> G (all modifiers optional)
+    {I, C, OPTIONAL_ALL},                   // I -> C (all modifiers optional)
+    {O, R, OPTIONAL_ALL},                   // O -> R (all modifiers optional)
+    {P, L, OPTIONAL_ALL},                   // P -> L (all modifiers optional)
+    {LEFT_BRACKET, SLASH, OPTIONAL_ALL},    // [ -> / (all modifiers optional)
+    {RIGHT_BRACKET, EQUAL, OPTIONAL_ALL},   // ] -> = (all modifiers optional)
+    {S, O, OPTIONAL_ALL},                   // S -> O (all modifiers optional)
+    {D, E, OPTIONAL_ALL},                   // D -> E (all modifiers optional)
+    {F, U, OPTIONAL_ALL},                   // F -> U (all modifiers optional)
+    {G, I, OPTIONAL_ALL},                   // G -> I (all modifiers optional)
+    {H, D, OPTIONAL_ALL},                   // H -> D (all modifiers optional)
+    {J, H, OPTIONAL_ALL},                   // J -> H (all modifiers optional)
+    {K, T, OPTIONAL_ALL},                   // K -> T (all modifiers optional)
+    {L, N, OPTIONAL_ALL},                   // L -> N (all modifiers optional)
+    {SEMICOLON, S, OPTIONAL_ALL},           // ; -> S (all modifiers optional)
+    {SINGLE_QUOTE, MINUS, OPTIONAL_ALL},    // ' -> - (all modifiers optional)
+    {Z, SEMICOLON, OPTIONAL_ALL},           // Z -> ; (all modifiers optional)
+    {X, Q, OPTIONAL_ALL},                   // X -> Q (all modifiers optional)
+    {C, J, OPTIONAL_ALL},                   // C -> J (all modifiers optional)
+    {V, K, OPTIONAL_ALL},                   // V -> K (all modifiers optional)
+    {B, X, OPTIONAL_ALL},                   // B -> X (all modifiers optional)
+    {N, B, OPTIONAL_ALL},                   // N -> B (all modifiers optional)
+    {COMMA, W, OPTIONAL_ALL},               // , -> W (all modifiers optional)
+    {DOT, V, OPTIONAL_ALL},                 // . -> V (all modifiers optional)
+    {SLASH, Z, OPTIONAL_ALL},               // / -> Z (all modifiers optional)
+};
+#endif

--- a/src/layouts/layout_jis.h
+++ b/src/layouts/layout_jis.h
@@ -1,0 +1,28 @@
+#ifdef CONFIG_LAYOUT_SHIFT_TARGET_JIS
+#define LAYOUT_DEFINED
+// Japanese (JIS) keyboard layout mappings
+// Maps US layout keycodes to their JIS equivalents
+static const struct keycode_mapping layout_map[] = {
+    /* from -> to, optional_modifiers */
+    {EQUAL,             UNDERSCORE,        OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* = -> _ (Ctrl/Alt/GUI optional) */
+    {CARET,             EQUAL,             OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ^ -> = (Ctrl/Alt/GUI optional) */
+    {TILDE,             PLUS,              OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ~ -> + (Ctrl/Alt/GUI optional) */
+    {AT_SIGN,           LEFT_BRACKET,      OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* @ -> [ (Ctrl/Alt/GUI optional) */
+    {GRAVE,             LEFT_BRACE,        OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ` -> { (Ctrl/Alt/GUI optional) */
+    {LEFT_BRACKET,      RIGHT_BRACKET,     OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* [ -> ] (Ctrl/Alt/GUI optional) */
+    {RIGHT_BRACKET,     BACKSLASH,         OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ] -> \ (Ctrl/Alt/GUI optional) */
+    {LEFT_BRACE,        RIGHT_BRACE,       OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* { -> } (Ctrl/Alt/GUI optional) */
+    {RIGHT_BRACE,       PIPE,              OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* } -> | (Ctrl/Alt/GUI optional) */
+    {PLUS,              COLON,             OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* + -> : (Ctrl/Alt/GUI optional) */
+    {COLON,             SINGLE_QUOTE,      OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* : -> ' (Ctrl/Alt/GUI optional) */
+    {ASTERISK,          DOUBLE_QUOTES,     OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* * -> " (Ctrl/Alt/GUI optional) */
+    {DOUBLE_QUOTES,     AT_SIGN,           OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* " -> @ (Ctrl/Alt/GUI optional) */
+    {AMPERSAND,         CARET,             OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* & -> ^ (Ctrl/Alt/GUI optional) */
+    {SINGLE_QUOTE,      AMPERSAND,         OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ' -> & (Ctrl/Alt/GUI optional) */
+    {LEFT_PARENTHESIS,  ASTERISK,          OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ( -> * (Ctrl/Alt/GUI optional) */
+    {RIGHT_PARENTHESIS, LEFT_PARENTHESIS,  OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ) -> ( (Ctrl/Alt/GUI optional) */
+    {UNDERSCORE,        LS(0x87),          OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* _      (Ctrl/Alt/GUI optional) */
+    {BACKSLASH,         0x89,              OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* \      (Ctrl/Alt/GUI optional) */
+    {PIPE,              LS(0x89),          OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* |      (Ctrl/Alt/GUI optional) */
+};
+#endif

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -1,0 +1,11 @@
+#ifdef CONFIG_LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
+#define LAYOUT_DEFINED
+// Swap Ctrl and Cmd
+static const struct keycode_mapping layout_map[] = {
+    /* from -> to, optional_modifiers */
+    {LEFT_CONTROL,  LEFT_COMMAND,  OPTIONAL_ALL},
+    {LEFT_COMMAND,  LEFT_CONTROL,  OPTIONAL_ALL},
+    {RIGHT_CONTROL, RIGHT_COMMAND, OPTIONAL_ALL},
+    {RIGHT_COMMAND, RIGHT_CONTROL, OPTIONAL_ALL},
+};
+#endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,6 @@
 build:
+  cmake: .
+  kconfig: Kconfig
   settings:
     board_root: .
+    dts_root: .


### PR DESCRIPTION
## 概要
- Mac/Win間のレイアウト切替ビヘイビアを追加
- ビヘイビアをデバイスツリー経由で利用可能にする設定を追加

## テスト
- `west build -s zmk/app -d build/left -b akdk_bt1 -- -DSHIELD=surround1x0_akdk_left -DZMK_CONFIG=$PWD/config -DBOARD_ROOT=$PWD` (Zephyr SDK が無いため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68aa7a4bb90c832c91e496aa8265aefa