### PR TITLE
feat: add mac/windows layout shift toggle

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -10,7 +10,7 @@ if LAYOUT_SHIFT
 
 choice LAYOUT_SHIFT_TARGET_LAYOUT
     prompt "Target keyboard layout"
-    default LAYOUT_SHIFT_TARGET_JIS
+    default LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
     help
       Select the target keyboard layout for layout shift mappings.
       This determines which key mappings are used when layout shift is active.
@@ -26,9 +26,9 @@ config LAYOUT_SHIFT_TARGET_DVORAK
       Dvorak keyboard layout mappings.
 
 config LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
-    bool "Swap Ctrl and Cmd"
+    bool "Mac/Windows modifier swap"
     help
-      Swap Ctrl / Cmd for Windows / Mac.
+      Rotate Ctrl, Alt and Cmd/Win modifiers for Mac vs. Windows layouts.
 
 endchoice
 

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -3,6 +3,7 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/pointing.h>
+#include "../dts/layout_shift.dtsi"
 
 // ZMK用のキーマップ設定ファイル
 // レイヤー構成:

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -70,40 +70,40 @@
 
         Default {
             bindings = <
-&mt ESC Q     &kp L        &kp U       &kp COMMA   &kp PERIOD     &mt CAPSLOCK DELETE                 &kp SPACE      &kp F  &kp W        &kp R       &kp Y       &kp P
-&kp E         &kp I        &kp A       &kp O       &kp MINUS      &mt HOME LEFT_ARROW                 &mt END RIGHT  &kp K  &kp T        &kp N       &kp S       &kp H
-&mt LSHIFT Z  &mt LCTRL X  &mt LALT C  &mt LGUI V  &kp SEMICOLON  &kp TAB                             &kp ENTER      &kp G  &mt RCTRL D  &mt RALT M  &mt RGUI J  &mt LSHIFT B
-                                       &kp RCTRL   &kp RALT       &kp LCMD             &kp LANG1      &kp LANG2
+&mtls ESC Q     &kp L        &kp U       &kp COMMA   &kp PERIOD     &mtls CAPSLOCK DELETE                 &kp SPACE      &kp F  &kp W        &kp R       &kp Y       &kp P
+&kp E         &kp I        &kp A       &kp O       &kp MINUS      &mtls HOME LEFT_ARROW                 &mtls END RIGHT  &kp K  &kp T        &kp N       &kp S       &kp H
+&mtls LSHIFT Z  &mtls LCTRL X  &mtls LALT C  &mtls LCMD V  &kp SEMICOLON  &kp TAB                             &kp ENTER      &kp G  &mtls RCTRL D  &mtls RALT M  &mtls RCMD J  &mtls LSHIFT B
+                                       &kpls RCTRL   &kpls RALT       &kpls LCMD             &kp LANG1      &kp LANG2
                                                    &moto 2 0      &moto 3 1            &kp BACKSPACE  &kp SPACE
             >;
         };
 
         Move {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
+&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
 &mo 5             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &mo 5
-&mt LEFT_SHIFT Z  &mt LCTRL X  &mt LALT C      &mt LGUI V     &none      &kp TAB                              &kp ENTER    &none  &kp RCTRL       &kp RALT         &kp RGUI  &kp RSHIFT
-                                               &kp LCTRL      &kp LALT   &kp LCMD             &msc SCRL_DOWN    &kp RS(TAB)
+&mtls LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
+                                               &kpls LCTRL      &kpls LALT   &kpls LCMD             &msc SCRL_DOWN    &kp RS(TAB)
                                                               &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
             >;
         };
 
         Char {
             bindings = <
-&kp ESCAPE  &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE       &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp MINUS      &kp EQUAL  &kp ASTERISK
+&kp ESCAPE  &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE       &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp MINUS      &kp EQUAL  &kp ASTERISK
 &mo 5       &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5        &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp SEMICOLON  &kp SQT    &kp GRAVE
-&kp LSHIFT  &kp LCTRL    &kp LALT        &kp LCMD       &none      &kp TAB                              &kp ENTER       &kp COMMA             &kp PERIOD             &kp BACKSLASH  &kp SLASH  &mt RSHIFT EXCLAMATION
-                                         &kp LCTRL      &kp LALT   &kp LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
+&kp LSHIFT  &kpls LCTRL    &kpls LALT        &kpls LCMD       &none      &kp TAB                              &kp ENTER       &kp COMMA             &kp PERIOD             &kp BACKSLASH  &kp SLASH  &mtls RSHIFT EXCLAMATION
+                                         &kpls LCTRL      &kpls LALT   &kpls LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
                                                         &moto 2 0  &moto 3 1            &kp BACKSPACE   &kp SPACE
             >;
         };
 
         Num {
             bindings = <
-&kp ESC     &kp PAGE_UP     &kp UP_ARROW    &kp PAGE_DOWN    &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE       &kp SLASH     &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp MINUS
+&kp ESC     &kp PAGE_UP     &kp UP_ARROW    &kp PAGE_DOWN    &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE       &kp SLASH     &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp MINUS
 &mo 5       &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &kp END    &mkp MB4                             &mkp MB5        &kp ASTERISK  &kp NUMBER_4  &kp N5        &kp NUMBER_6  &kp PLUS
-&kp LSHIFT  &kp LCTRL       &kp LALT        &kp LGUI         &none      &kp TAB                              &kp ENTER       &kp NUMBER_0  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp PERIOD
-                                            &kp LCTRL        &kp LALT   &kp LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
+&kp LSHIFT  &kpls LCTRL       &kpls LALT        &kpls LCMD         &none      &kp TAB                              &kp ENTER       &kp NUMBER_0  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp PERIOD
+                                            &kpls LCTRL        &kpls LALT   &kpls LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
                                                              &moto 2 0  &moto 3 1            &kp BACKSPACE   &kp SPACE
             >;
         };
@@ -120,10 +120,10 @@
 
         Scroll {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
+&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
 &none             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &none
-&mt LEFT_SHIFT Z  &mt LCTRL X  &mt LALT C      &mt LGUI V     &none      &kp TAB                              &kp ENTER    &none  &kp RCTRL       &kp RALT         &kp RGUI  &kp RSHIFT
-                                               &kp LCTRL      &kp LALT   &kp LCMD             &msc SCRL_DOWN    &kp RS(TAB)
+&mtls LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
+                                               &kpls LCTRL      &kpls LALT   &kpls LCMD             &msc SCRL_DOWN    &kp RS(TAB)
                                                               &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
             >;
         };
@@ -140,7 +140,8 @@
 
         Setting {
             bindings = <
-&none  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
+&tog_ls  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3
+&bt BT_SEL 4
 &none  &none  &none  &none  &none  &studio_unlock         &none         &none         &none         &none         &none         &none
 &none  &none  &none  &none  &none  &none                  &none         &none         &none         &none         &bt BT_PRV    &bt BT_NXT
                      &none  &none  &none           &none  &none

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -1,11 +1,17 @@
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
 #define LAYOUT_DEFINED
-// Swap Ctrl and Cmd
+// Rotate modifier keys to match Mac/Windows layouts
+// Default (layout shift off): Mac layout (Ctrl-Opt-Cmd)
+// Layout shift on: rotate Cmd→Ctrl→Alt→Win→Cmd
 static const struct keycode_mapping layout_map[] = {
     /* from -> to, optional_modifiers */
-    {LEFT_CONTROL,  LEFT_COMMAND,  OPTIONAL_ALL},
-    {LEFT_COMMAND,  LEFT_CONTROL,  OPTIONAL_ALL},
-    {RIGHT_CONTROL, RIGHT_COMMAND, OPTIONAL_ALL},
-    {RIGHT_COMMAND, RIGHT_CONTROL, OPTIONAL_ALL},
+    {LEFT_COMMAND,  LEFT_CONTROL, OPTIONAL_ALL},  /* Cmd -> Ctrl */
+    {LEFT_CONTROL,  LEFT_ALT,     OPTIONAL_ALL},  /* Ctrl -> Alt */
+    {LEFT_ALT,      LEFT_GUI,     OPTIONAL_ALL},  /* Alt -> Win */
+    {LEFT_GUI,      LEFT_COMMAND, OPTIONAL_ALL},  /* Win -> Cmd */
+    {RIGHT_COMMAND, RIGHT_CONTROL, OPTIONAL_ALL}, /* Cmd -> Ctrl */
+    {RIGHT_CONTROL, RIGHT_ALT,    OPTIONAL_ALL},  /* Ctrl -> Alt */
+    {RIGHT_ALT,     RIGHT_GUI,    OPTIONAL_ALL},  /* Alt -> Win */
+    {RIGHT_GUI,     RIGHT_COMMAND, OPTIONAL_ALL}, /* Win -> Cmd */
 };
 #endif


### PR DESCRIPTION
## Summary
- rotate modifier keys through Cmd→Ctrl→Alt→Win for layout shift between macOS and Windows
- default to Mac modifier order and expose layout shift toggle in keymap

## Testing
- `west build -b akdk_bt1 -s . -- -DSHIELD=surround1x0_akdk_left` *(fails: west: unknown command "build"; do you need to run this inside a workspace?)*

------
https://chatgpt.com/codex/tasks/task_e_68aa83185038832c885ed872d094f194