### PR TITLE
レイヤーシフト版モーメンタリーレイヤー&molsを追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CONFIG_LAYOUT_SHIFT)
     target_sources_ifdef(CONFIG_LAYOUT_SHIFT app PRIVATE
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_key_press.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_toggle.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_momentary_layer_shift.c
     )
   endif()
 endif()

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -62,6 +62,11 @@
             #binding-cells = <2>;
             tapping-term-ms = <300>;
         };
+
+        // mols_demo: placeholder for layout shift momentary layer behavior
+        // mols_demo {
+        //     bindings = <&mols 6>; // TODO: Replace 6 with base layer, shifted layer defined in layout
+        // };
     };
 
     keymap {

--- a/dts/bindings/behaviors/zmk,behavior-mols.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-mols.yaml
@@ -3,6 +3,6 @@
 
 description: Momentary layer behavior that selects the target layer based on the current layout shift state
 
-compatible: "zmk,behavior-momentary-layer-shift"
+compatible: "zmk,behavior-mols"
 
 include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-momentary-layer-shift.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-momentary-layer-shift.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Momentary layer behavior that selects the target layer based on the current layout shift state
+
+compatible: "zmk,behavior-momentary-layer-shift"
+
+include: one_param.yaml

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -28,6 +28,14 @@
             display-name = "Mod-Tap with Layout Shift";
         };
 
+        // Layout-aware momentary layer behavior alias
+        mols: layout_shift_momentary_layer {
+            compatible = "zmk,behavior-momentary-layer-shift";
+            #binding-cells = <1>;
+            label = "LAYOUT_SHIFT_MO";
+            display-name = "Momentary Layer with Layout Shift";
+        };
+
         // Layout shift toggle behaviors
         tog_ls: toggle_layout_shift {
             compatible = "zmk,behavior-layout-shift-toggle";

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -30,7 +30,7 @@
 
         // Layout-aware momentary layer behavior alias
         mols: layout_shift_momentary_layer {
-            compatible = "zmk,behavior-momentary-layer-shift";
+            compatible = "zmk,behavior-mols";
             #binding-cells = <1>;
             label = "LAYOUT_SHIFT_MO";
             display-name = "Momentary Layer with Layout Shift";

--- a/src/behavior_momentary_layer_shift.c
+++ b/src/behavior_momentary_layer_shift.c
@@ -1,4 +1,4 @@
-#define DT_DRV_COMPAT zmk_behavior_momentary_layer_shift
+#define DT_DRV_COMPAT zmk_behavior_mols
 
 #include "layouts/layout_common.h"
 #include <drivers/behavior.h>

--- a/src/behavior_momentary_layer_shift.c
+++ b/src/behavior_momentary_layer_shift.c
@@ -1,5 +1,6 @@
 #define DT_DRV_COMPAT zmk_behavior_momentary_layer_shift
 
+#include "layouts/layout_common.h"
 #include <drivers/behavior.h>
 #include <stddef.h>
 #include <zephyr/device.h>

--- a/src/behavior_momentary_layer_shift.c
+++ b/src/behavior_momentary_layer_shift.c
@@ -1,0 +1,97 @@
+#define DT_DRV_COMPAT zmk_behavior_momentary_layer_shift
+
+#include <drivers/behavior.h>
+#include <stddef.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zmk/behavior.h>
+#include <zmk/keymap.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+// External function to check layout shift state
+extern bool zmk_layout_shift_is_active(void);
+
+struct layer_mapping {
+  uint8_t base_layer;
+  uint8_t shift_layer;
+};
+
+#define DEFINE_LAYER_MAPPING
+#include "layouts/index.h"
+#undef DEFINE_LAYER_MAPPING
+
+#ifdef LAYER_MAP_DEFINED
+#define LAYER_MAP_SIZE (sizeof(layer_map) / sizeof(layer_map[0]))
+#else
+#define LAYER_MAP_SIZE 0
+static const struct layer_mapping layer_map[0];
+#endif
+
+struct behavior_momentary_layer_shift_config {};
+
+struct behavior_momentary_layer_shift_data {
+  uint8_t active_layer;
+};
+
+static int mols_binding_pressed(struct zmk_behavior_binding *binding,
+                                struct zmk_behavior_binding_event event) {
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  struct behavior_momentary_layer_shift_data *data = dev->data;
+
+  uint8_t base_layer = binding->param1;
+  uint8_t target_layer = base_layer;
+
+  if (zmk_layout_shift_is_active()) {
+    for (size_t i = 0; i < LAYER_MAP_SIZE; i++) {
+      if (layer_map[i].base_layer == base_layer) {
+        target_layer = layer_map[i].shift_layer;
+        break;
+      }
+    }
+  }
+
+  data->active_layer = target_layer;
+  return zmk_keymap_layer_activate(target_layer);
+}
+
+static int mols_binding_released(struct zmk_behavior_binding *binding,
+                                 struct zmk_behavior_binding_event event) {
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  struct behavior_momentary_layer_shift_data *data = dev->data;
+
+  return zmk_keymap_layer_deactivate(data->active_layer);
+}
+
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+static const struct behavior_parameter_value_metadata param_values[] = {
+    {
+        .display_name = "Layer",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_LAYER_ID,
+    },
+};
+
+static const struct behavior_parameter_metadata_set param_metadata_set[] = {{
+    .param1_values = &param_values[0],
+    .param1_values_len = 1,
+}};
+
+static const struct behavior_parameter_metadata mols_parameter_metadata = {
+    .sets_len = ARRAY_SIZE(param_metadata_set),
+    .sets = param_metadata_set,
+};
+#endif
+
+static const struct behavior_driver_api
+    behavior_momentary_layer_shift_driver_api = {
+        .binding_pressed = mols_binding_pressed,
+        .binding_released = mols_binding_released,
+        .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+        .parameter_metadata = &mols_parameter_metadata,
+#endif
+};
+
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_momentary_layer_shift_driver_api);

--- a/src/behavior_momentary_layer_shift.c
+++ b/src/behavior_momentary_layer_shift.c
@@ -93,6 +93,12 @@ static const struct behavior_driver_api
 #endif
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-                        &behavior_momentary_layer_shift_driver_api);
+// Define behavior instances only if devicetree nodes exist
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define MOLS_INST(n)                                                           \
+  BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,              \
+                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                 \
+                          &behavior_momentary_layer_shift_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MOLS_INST)
+#endif

--- a/src/layouts/layout_common.h
+++ b/src/layouts/layout_common.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <dt-bindings/zmk/modifiers.h>
+#include <zmk/hid.h>
+#include <zmk/keys.h>
+
+struct keycode_mapping {
+  uint32_t us_keycode;
+  uint32_t target_keycode;
+  zmk_mod_flags_t optional_modifiers;
+};
+
+#define OPTIONAL_SHIFT (MOD_LSFT | MOD_RSFT)
+#define OPTIONAL_CTRL (MOD_LCTL | MOD_RCTL)
+#define OPTIONAL_ALT (MOD_LALT | MOD_RALT)
+#define OPTIONAL_GUI (MOD_LGUI | MOD_RGUI)
+#define OPTIONAL_ALL (0xFF)
+#define OPTIONAL_NONE (0)

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -5,13 +5,19 @@
 // Layout shift on: rotate Cmd→Ctrl→Alt→Win→Cmd
 static const struct keycode_mapping layout_map[] = {
     /* from -> to, optional_modifiers */
-    {LEFT_COMMAND,  LEFT_CONTROL, OPTIONAL_ALL},  /* Cmd -> Ctrl */
-    {LEFT_CONTROL,  LEFT_ALT,     OPTIONAL_ALL},  /* Ctrl -> Alt */
-    {LEFT_ALT,      LEFT_GUI,     OPTIONAL_ALL},  /* Alt -> Win */
-    {LEFT_GUI,      LEFT_COMMAND, OPTIONAL_ALL},  /* Win -> Cmd */
+    {LEFT_COMMAND, LEFT_CONTROL, OPTIONAL_ALL},   /* Cmd -> Ctrl */
+    {LEFT_CONTROL, LEFT_ALT, OPTIONAL_ALL},       /* Ctrl -> Alt */
+    {LEFT_ALT, LEFT_GUI, OPTIONAL_ALL},           /* Alt -> Win */
+    {LEFT_GUI, LEFT_COMMAND, OPTIONAL_ALL},       /* Win -> Cmd */
     {RIGHT_COMMAND, RIGHT_CONTROL, OPTIONAL_ALL}, /* Cmd -> Ctrl */
-    {RIGHT_CONTROL, RIGHT_ALT,    OPTIONAL_ALL},  /* Ctrl -> Alt */
-    {RIGHT_ALT,     RIGHT_GUI,    OPTIONAL_ALL},  /* Alt -> Win */
-    {RIGHT_GUI,     RIGHT_COMMAND, OPTIONAL_ALL}, /* Win -> Cmd */
+    {RIGHT_CONTROL, RIGHT_ALT, OPTIONAL_ALL},     /* Ctrl -> Alt */
+    {RIGHT_ALT, RIGHT_GUI, OPTIONAL_ALL},         /* Alt -> Win */
+    {RIGHT_GUI, RIGHT_COMMAND, OPTIONAL_ALL},     /* Win -> Cmd */
 };
+#ifdef DEFINE_LAYER_MAPPING
+static const struct layer_mapping layer_map[] = {
+    {6, 7}, /* Layer 6 -> Layer 7 when layout shift is active */
+};
+#define LAYER_MAP_DEFINED
+#endif
 #endif


### PR DESCRIPTION
## 概要
- レイヤーシフト状態に応じてレイヤー番号を差し替える`&mols`を単一引数で実装
- レイヤー対応表をレイアウトファイルで定義できるようにし、例としてlayer 6→7のマッピングを追加
- DTSとキーマップの`&mols`バインディングを1引数仕様に更新

## テスト
- `clang-format --dry-run -Werror src/behavior_momentary_layer_shift.c src/layouts/layout_swap_ctrl_cmd.h`
- `west build -b akdk_bt1 -s . -- -DSHIELD=surround1x0_akdk_left` (west未インストールのため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68aac39d7c28832c9c39c83ae44c3eaa