### PR TITLE
マウスレイヤのスクロール切替にmolsビヘイビアを導入

### DIFF
--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -90,7 +90,7 @@
         Move {
             bindings = <
 &kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
-&mo 5             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                             &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &mo 5
+&mols 5           &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                             &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &mols 5
 &mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                              &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
                                                  &kpls LCTRL    &kpls LALT  &kpls LCMD           &msc SCRL_DOWN  &kp RS(TAB)
                                                                 &moto 2 0   &moto 3 1            &msc SCRL_UP    &kp TAB

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -16,7 +16,7 @@ static const struct keycode_mapping layout_map[] = {
 };
 #ifdef DEFINE_LAYER_MAPPING
 static const struct layer_mapping layer_map[] = {
-    {6, 7}, /* Layer 6 -> Layer 7 when layout shift is active */
+    {5, 6}, /* Layer 5 -> Layer 6 when layout shift is active */
 };
 #define LAYER_MAP_DEFINED
 #endif


### PR DESCRIPTION
## 概要
- マウスレイヤのスクロール切替を`&mo`から`&mols`に変更
- レイアウトシフト用のレイヤマッピングを現行キーマップに合わせて更新

## テスト
- `west build -s zmk/app -d build/left -b akdk_bt1 -- -DSHIELD=surround1x0_akdk_left` :heavy_exclamation_mark: モジュール取得段階で中断

------
https://chatgpt.com/codex/tasks/task_e_68aad45f547c832c822f6bef66e90804