### PR TITLE
msclsでレイヤーシフト時のスクロール切替に対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CONFIG_LAYOUT_SHIFT)
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_key_press.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_toggle.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_momentary_layer_shift.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_mouse_scroll.c
     )
   endif()
 endif()

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -89,11 +89,11 @@
 
         Move {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mt CAPSLOCK DELETE                  &kp SPACE    &none  &mscls SCRL_RIGHT  &mscls SCRL_LEFT  &none       &none
 &mols 5           &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                             &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &mols 5
 &mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                              &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
-                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD           &msc SCRL_DOWN  &kp RS(TAB)
-                                                                &moto 2 0   &moto 3 1            &msc SCRL_UP    &kp TAB
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD           &mscls SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1            &mscls SCRL_UP    &kp TAB
             >;
         };
 
@@ -129,21 +129,21 @@
 
         ScrollMac {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &mscls SCRL_RIGHT  &mscls SCRL_LEFT  &none       &none
 &none             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                               &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &none
 &mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                                &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
-                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &msc SCRL_DOWN  &kp RS(TAB)
-                                                                &moto 2 0   &moto 3 1              &msc SCRL_UP    &kp TAB
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &mscls SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1              &mscls SCRL_UP    &kp TAB
             >;
         };
 
         ScrollWin {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &mscls SCRL_RIGHT  &mscls SCRL_LEFT  &none       &none
 &none             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                               &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &none
 &mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                                &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
-                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &msc SCRL_DOWN  &kp RS(TAB)
-                                                                &moto 2 0   &moto 3 1              &msc SCRL_UP    &kp TAB
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &mscls SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1              &mscls SCRL_UP    &kp TAB
             >;
         };
 

--- a/dts/bindings/behaviors/zmk,behavior-mscls.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-mscls.yaml
@@ -1,0 +1,11 @@
+description: Layout shift-aware mouse scroll behavior that maps scroll direction based on the current layout shift state
+
+compatible: "zmk,behavior-mscls"
+
+include: one_param.yaml
+
+properties:
+  msc:
+    type: phandle
+    required: true
+    description: Mouse scroll device used to send scroll events

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -9,56 +9,72 @@
 #include <dt-bindings/zmk/keys.h>
 
 / {
-    behaviors {
-        // Layout-aware key press behavior alias
-        kpls: layout_shift_key_press {
-            compatible = "zmk,behavior-layout-shift-key-press";
-            #binding-cells = <1>;
-            label = "LAYOUT_SHIFT_KEY_PRESS";
-            display-name = "Key Press with Layout Shift";
-        };
-
-        // Layout-aware mod-tap behavior alias
-        mtls: layout_shift_mod_tap {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "hold-preferred";
-            tapping-term-ms = <200>;
-            bindings = <&kpls>, <&kpls>;
-            display-name = "Mod-Tap with Layout Shift";
-        };
-
-        // Layout-aware momentary layer behavior alias
-        mols: layout_shift_momentary_layer {
-            compatible = "zmk,behavior-mols";
-            #binding-cells = <1>;
-            label = "LAYOUT_SHIFT_MO";
-            display-name = "Momentary Layer with Layout Shift";
-        };
-
-        // Layout shift toggle behaviors
-        tog_ls: toggle_layout_shift {
-            compatible = "zmk,behavior-layout-shift-toggle";
-            #binding-cells = <0>;
-            toggle-mode = "flip";
-            label = "LAYOUT_SHIFT_TOGGLE";
-            display-name = "Toggle Layout Shift";
-        };
-
-        tog_ls_on: toggle_layout_shift_on {
-            compatible = "zmk,behavior-layout-shift-toggle";
-            #binding-cells = <0>;
-            toggle-mode = "on";
-            label = "LAYOUT_SHIFT_TOGGLE_ON";
-            display-name = "Toggle Layout Shift On";
-        };
-
-        tog_ls_off: toggle_layout_shift_off {
-            compatible = "zmk,behavior-layout-shift-toggle";
-            #binding-cells = <0>;
-            toggle-mode = "off";
-            label = "LAYOUT_SHIFT_TOGGLE_OFF";
-            display-name = "Toggle Layout Shift Off";
-        };
+  behaviors {
+  // Layout-aware key press behavior alias
+  kpls:
+    layout_shift_key_press {
+      compatible = "zmk,behavior-layout-shift-key-press";
+#binding-cells = <1>;
+      label = "LAYOUT_SHIFT_KEY_PRESS";
+      display-name = "Key Press with Layout Shift";
     };
+
+  // Layout-aware mod-tap behavior alias
+  mtls:
+    layout_shift_mod_tap {
+      compatible = "zmk,behavior-hold-tap";
+#binding-cells = <2>;
+      flavor = "hold-preferred";
+      tapping-term-ms = <200>;
+      bindings = <&kpls>, <&kpls>;
+      display-name = "Mod-Tap with Layout Shift";
+    };
+
+  // Layout-aware momentary layer behavior alias
+  mols:
+    layout_shift_momentary_layer {
+      compatible = "zmk,behavior-mols";
+#binding-cells = <1>;
+      label = "LAYOUT_SHIFT_MO";
+      display-name = "Momentary Layer with Layout Shift";
+    };
+
+  // Layout-aware mouse scroll behavior alias
+  mscls:
+    layout_shift_mouse_scroll {
+      compatible = "zmk,behavior-mscls";
+#binding-cells = <1>;
+      msc = <&msc>;
+      label = "LAYOUT_SHIFT_MOUSE_SCROLL";
+      display-name = "Mouse Scroll with Layout Shift";
+    };
+
+  // Layout shift toggle behaviors
+  tog_ls:
+    toggle_layout_shift {
+      compatible = "zmk,behavior-layout-shift-toggle";
+#binding-cells = <0>;
+      toggle-mode = "flip";
+      label = "LAYOUT_SHIFT_TOGGLE";
+      display-name = "Toggle Layout Shift";
+    };
+
+  tog_ls_on:
+    toggle_layout_shift_on {
+      compatible = "zmk,behavior-layout-shift-toggle";
+#binding-cells = <0>;
+      toggle-mode = "on";
+      label = "LAYOUT_SHIFT_TOGGLE_ON";
+      display-name = "Toggle Layout Shift On";
+    };
+
+  tog_ls_off:
+    toggle_layout_shift_off {
+      compatible = "zmk,behavior-layout-shift-toggle";
+#binding-cells = <0>;
+      toggle-mode = "off";
+      label = "LAYOUT_SHIFT_TOGGLE_OFF";
+      display-name = "Toggle Layout Shift Off";
+    };
+  };
 };

--- a/src/behavior_layout_shift_mouse_scroll.c
+++ b/src/behavior_layout_shift_mouse_scroll.c
@@ -1,0 +1,83 @@
+#define DT_DRV_COMPAT zmk_behavior_mscls
+
+#include "layouts/layout_common.h"
+#include <drivers/behavior.h>
+#include <dt-bindings/zmk/pointing.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zmk/behavior.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+extern bool zmk_layout_shift_is_active(void);
+
+#define DEFINE_MSC_MAPPING
+#include "layouts/index.h"
+#undef DEFINE_MSC_MAPPING
+
+#ifdef MSC_MAP_DEFINED
+#define MSC_MAP_SIZE (sizeof(msc_map) / sizeof(msc_map[0]))
+#else
+#define MSC_MAP_SIZE 0
+static const struct msc_mapping msc_map[0];
+#endif
+
+struct behavior_mscls_config {
+  const struct device *msc_dev;
+};
+
+static uint32_t lookup_mapped_msc(uint32_t code) {
+  if (!zmk_layout_shift_is_active()) {
+    return code;
+  }
+  for (size_t i = 0; i < MSC_MAP_SIZE; i++) {
+    if (msc_map[i].base == code) {
+      return msc_map[i].shifted;
+    }
+  }
+  return code;
+}
+
+extern int behavior_input_two_axis_adjust_speed(const struct device *dev,
+                                                int16_t dx, int16_t dy);
+
+static int mscls_binding_pressed(struct zmk_behavior_binding *binding,
+                                 struct zmk_behavior_binding_event event) {
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  const struct behavior_mscls_config *cfg = dev->config;
+
+  uint32_t mapped = lookup_mapped_msc(binding->param1);
+  int16_t x = MOVE_X_DECODE(mapped);
+  int16_t y = MOVE_Y_DECODE(mapped);
+  behavior_input_two_axis_adjust_speed(cfg->msc_dev, x, y);
+  return 0;
+}
+
+static int mscls_binding_released(struct zmk_behavior_binding *binding,
+                                  struct zmk_behavior_binding_event event) {
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  const struct behavior_mscls_config *cfg = dev->config;
+
+  uint32_t mapped = lookup_mapped_msc(binding->param1);
+  int16_t x = MOVE_X_DECODE(mapped);
+  int16_t y = MOVE_Y_DECODE(mapped);
+  behavior_input_two_axis_adjust_speed(cfg->msc_dev, -x, -y);
+  return 0;
+}
+
+static const struct behavior_driver_api behavior_mscls_driver_api = {
+    .binding_pressed = mscls_binding_pressed,
+    .binding_released = mscls_binding_released,
+};
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define MSCLS_INST(n)                                                          \
+  static const struct behavior_mscls_config behavior_mscls_config_##n = {      \
+      .msc_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, msc)),                       \
+  };                                                                           \
+  BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, &behavior_mscls_config_##n,     \
+                          POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,    \
+                          &behavior_mscls_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MSCLS_INST)
+#endif

--- a/src/layouts/layout_common.h
+++ b/src/layouts/layout_common.h
@@ -10,6 +10,11 @@ struct keycode_mapping {
   zmk_mod_flags_t optional_modifiers;
 };
 
+struct msc_mapping {
+  uint32_t base;
+  uint32_t shifted;
+};
+
 #define OPTIONAL_SHIFT (MOD_LSFT | MOD_RSFT)
 #define OPTIONAL_CTRL (MOD_LCTL | MOD_RCTL)
 #define OPTIONAL_ALT (MOD_LALT | MOD_RALT)

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -1,5 +1,7 @@
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
 #define LAYOUT_DEFINED
+#include <dt-bindings/zmk/pointing.h>
+
 // Rotate modifier keys to match Mac/Windows layouts
 // Default (layout shift off): Mac layout (Ctrl-Opt-Cmd)
 // Layout shift on: rotate Cmd→Ctrl→Alt→Win→Cmd
@@ -14,6 +16,15 @@ static const struct keycode_mapping layout_map[] = {
     {RIGHT_ALT, RIGHT_GUI, OPTIONAL_ALL},         /* Alt -> Win */
     {RIGHT_GUI, RIGHT_COMMAND, OPTIONAL_ALL},     /* Win -> Cmd */
 };
+#ifdef DEFINE_MSC_MAPPING
+static const struct msc_mapping msc_map[] = {
+    {SCRL_UP, SCRL_DOWN},
+    {SCRL_DOWN, SCRL_UP},
+    {SCRL_LEFT, SCRL_RIGHT},
+    {SCRL_RIGHT, SCRL_LEFT},
+};
+#define MSC_MAP_DEFINED
+#endif
 #ifdef DEFINE_LAYER_MAPPING
 static const struct layer_mapping layer_map[] = {
     {5, 6}, /* Layer 5 -> Layer 6 when layout shift is active */


### PR DESCRIPTION
## 概要
- レイヤーシフト状態に応じてスクロール方向を切り替える`mscls`挙動を追加
- `layout_swap_ctrl_cmd`にスクロール方向のマッピングを追加し、キー設定を`mscls`へ置き換え
- ビルド設定とdtsiを更新

## テスト
- `west build -b akdk_bt1 -s . -- -DSHIELD=surround1x0_akdk_left` (コマンドが見つからず実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68aadcde9630832c98a072b863de01d7