### PR TITLE
ソースコードのライセンス表記追加

### DIFF
--- a/src/behavior_layout_shift_key_press.c
+++ b/src/behavior_layout_shift_key_press.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_layout_shift_key_press
 
 #include <drivers/behavior.h>

--- a/src/behavior_layout_shift_mouse_scroll.c
+++ b/src/behavior_layout_shift_mouse_scroll.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_mscls
 
 #include "layouts/layout_common.h"

--- a/src/behavior_layout_shift_to.c
+++ b/src/behavior_layout_shift_to.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_layout_shift_to
 
 #include <drivers/behavior.h>

--- a/src/behavior_layout_shift_toggle.c
+++ b/src/behavior_layout_shift_toggle.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_layout_shift_toggle
 
 #include <zephyr/device.h>

--- a/src/behavior_momentary_layer_shift.c
+++ b/src/behavior_momentary_layer_shift.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_mols
 
 #include "layouts/layout_common.h"

--- a/src/layouts/index.h
+++ b/src/layouts/index.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 // Layout index - includes all available layout definitions
 // Each layout file contains its own conditional compilation directives
 

--- a/src/layouts/layout_common.h
+++ b/src/layouts/layout_common.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #pragma once
 
 #include <dt-bindings/zmk/modifiers.h>

--- a/src/layouts/layout_dvorak.h
+++ b/src/layouts/layout_dvorak.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_DVORAK
 #define LAYOUT_DEFINED
 // Dvorak keyboard layout mappings

--- a/src/layouts/layout_jis.h
+++ b/src/layouts/layout_jis.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_JIS
 #define LAYOUT_DEFINED
 // Japanese (JIS) keyboard layout mappings

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
 #define LAYOUT_DEFINED
 #include <dt-bindings/zmk/pointing.h>


### PR DESCRIPTION
## 概要
- レイアウトシフト関連のソースおよびレイアウトヘッダーにMITライセンス表記を追加
- 元リポジトリ(kot149/zmk-layout-shift)へのリンクと作者名を明記

## テスト
- コメントのみの変更のためテストなし

------
https://chatgpt.com/codex/tasks/task_e_68ac746c7268832c8e82c4479978d594