### PR TITLE
feat レイヤーシフトによりwindowsでの使用に対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CONFIG_LAYOUT_SHIFT)
     target_sources_ifdef(CONFIG_LAYOUT_SHIFT app PRIVATE
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_key_press.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_toggle.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_to.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_momentary_layer_shift.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_mouse_scroll.c
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CONFIG_LAYOUT_SHIFT)
     target_sources_ifdef(CONFIG_LAYOUT_SHIFT app PRIVATE
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_key_press.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_toggle.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_momentary_layer_shift.c
     )
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.20.5)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(zmk-layout-shift)
+
+if(CONFIG_LAYOUT_SHIFT)
+  if ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    target_sources_ifdef(CONFIG_LAYOUT_SHIFT app PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_key_press.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_toggle.c
+    )
+  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CONFIG_LAYOUT_SHIFT)
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_key_press.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_toggle.c
       ${CMAKE_CURRENT_LIST_DIR}/src/behavior_momentary_layer_shift.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_shift_mouse_scroll.c
     )
   endif()
 endif()

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,43 @@
+# zmk-layout-shift Kconfig
+
+config LAYOUT_SHIFT
+    bool "Layout Shift"
+    default y
+    help
+      Enable the Layout Shift module.
+
+if LAYOUT_SHIFT
+
+choice LAYOUT_SHIFT_TARGET_LAYOUT
+    prompt "Target keyboard layout"
+    default LAYOUT_SHIFT_TARGET_JIS
+    help
+      Select the target keyboard layout for layout shift mappings.
+      This determines which key mappings are used when layout shift is active.
+
+config LAYOUT_SHIFT_TARGET_JIS
+    bool "Japanese (JIS)"
+    help
+      Japanese keyboard layout mappings.
+
+config LAYOUT_SHIFT_TARGET_DVORAK
+    bool "Dvorak"
+    help
+      Dvorak keyboard layout mappings.
+
+config LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
+    bool "Swap Ctrl and Cmd"
+    help
+      Swap Ctrl / Cmd for Windows / Mac.
+
+endchoice
+
+config LAYOUT_SHIFT_PERSISTENT_STATE
+    bool "Layout Shift Persistent State"
+    default y
+    select SETTINGS
+    help
+      Enable persistent storage of layout shift state across reboots.
+      This feature requires CONFIG_SETTINGS to be enabled.
+
+endif

--- a/Kconfig
+++ b/Kconfig
@@ -10,7 +10,7 @@ if LAYOUT_SHIFT
 
 choice LAYOUT_SHIFT_TARGET_LAYOUT
     prompt "Target keyboard layout"
-    default LAYOUT_SHIFT_TARGET_JIS
+    default LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
     help
       Select the target keyboard layout for layout shift mappings.
       This determines which key mappings are used when layout shift is active.
@@ -26,9 +26,9 @@ config LAYOUT_SHIFT_TARGET_DVORAK
       Dvorak keyboard layout mappings.
 
 config LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
-    bool "Swap Ctrl and Cmd"
+    bool "Mac/Windows modifier swap"
     help
-      Swap Ctrl / Cmd for Windows / Mac.
+      Rotate Ctrl, Alt and Cmd/Win modifiers for Mac vs. Windows layouts.
 
 endchoice
 

--- a/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
+++ b/boards/shields/surround1x0_akdk/surround1x0_akdk_right.overlay
@@ -50,21 +50,20 @@
         device = <&trackball>;
         /* Pointer系: ハードの向き補正として X と Y を反転（スクロールとは別パイプライン） */
         input-processors = <&zip_xy_transform (INPUT_TRANSFORM_X_INVERT | INPUT_TRANSFORM_Y_INVERT)>;
-        
-        /* Scroll系 (Mac): Xのみ反転。ナチュラルスクロールON時に従来の体感へ */
-        /* Mac用: ナチュラルスクロールON時 */
+
+        /* Scroll系: Mac/Win で個別にマッピング */
         scroller_mac {
+            /* Mac用: ナチュラルスクロールON時、従来体感に合わせてXのみ反転 */
             layers = <5>;
             input-processors = <&zip_xy_to_scroll_mapper>, <&zip_scroll_transform (INPUT_TRANSFORM_X_INVERT)>, <&zip_scroll_scaler 1 128>;
             process-next;
+        };
 
-        /* Win用: TODO */
-        /* scroller_win {
-            layers = <6>; // Win用スクロールレイヤを設定（必要に応じて変更）
+        scroller_win {
+            /* Win用: 通常の体感に合わせてYのみ反転 */
+            layers = <6>;
             input-processors = <&zip_xy_to_scroll_mapper>, <&zip_scroll_transform (INPUT_TRANSFORM_Y_INVERT)>, <&zip_scroll_scaler 1 128>;
             process-next;
-        }; */
-
         };
     };
 };

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -6,13 +6,16 @@
 #include "../dts/layout_shift.dtsi"
 
 // ZMK用のキーマップ設定ファイル
-// レイヤー構成:
-// - Default: 通常のタイピング用
-// - Move: カーソル移動・スクロール・マウス入力用
-// - Char: 記号や括弧などの入力用
-// - num: 数字入力・テンキー配列
-// - function: ファンクションキー (F1〜F12)
-// - bt: Bluetoothデバイス選択と切替操作
+// レイヤー構成（上から定義順 = レイヤー番号）:
+// 0: Default     …… 通常のタイピング用
+// 1: Move        …… カーソル移動・スクロール・マウス入力用
+// 2: Char        …… 記号や括弧などの入力用
+// 3: Num         …… 数字入力・テンキー配列
+// 4: Function    …… ファンクションキー (F1〜F12)
+// 5: ScrollMac   …… スクロール・トラックボール操作 (Mac用)
+// 6: ScrollWin   …… スクロール・トラックボール操作 (Windows用)
+// 7: Recess      …… すべてのレイヤーを無効化してデフォルトに戻す
+// 8: Setting     …… Bluetooth選択/切替・出力切替・レイアウトシフト等の設定
 
 / {
     combos {
@@ -27,14 +30,14 @@
         // Bluetooth設定レイヤーに一時移動
 
         moSettings {
-            bindings = <&mo 7>;
+            bindings = <&mo 8>;
             key-positions = <0 12 24>;
         };
 
         // すべてのレイヤーを無効化してデフォルトレイヤーに戻す
 
         moRecess {
-            bindings = <&mo 6>;
+            bindings = <&mo 7>;
             key-positions = <1 13 25>;
         };
 
@@ -124,7 +127,17 @@
             >;
         };
 
-        Scroll {
+        ScrollMac {
+            bindings = <
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&none             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                               &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &none
+&mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                                &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &msc SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1              &msc SCRL_UP    &kp TAB
+            >;
+        };
+
+        ScrollWin {
             bindings = <
 &kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
 &none             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                               &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &none

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -71,41 +71,41 @@
 
         Default {
             bindings = <
-&mt ESC Q     &kp L        &kp U       &kp COMMA   &kp PERIOD     &mt CAPSLOCK DELETE                 &kp SPACE      &kp F  &kp W        &kp R       &kp Y       &kp P
-&kp E         &kp I        &kp A       &kp O       &kp MINUS      &mt HOME LEFT_ARROW                 &mt END RIGHT  &kp K  &kp T        &kp N       &kp S       &kp H
-&mt LSHIFT Z  &mtls LCTRL X  &mtls LALT C  &mtls LCMD V  &kp SEMICOLON  &kp TAB                             &kp ENTER      &kp G  &mtls RCTRL D  &mtls RALT M  &mtls RCMD J  &mt LSHIFT B
-                                       &kpls RCTRL   &kpls RALT       &kpls LCMD             &kp LANG1      &kp LANG2
-                                                   &moto 2 0      &moto 3 1            &kp BACKSPACE  &kp SPACE
+&mt ESC Q     &kp L          &kp U         &kp COMMA     &kp PERIOD     &mt CAPSLOCK DELETE                 &kp SPACE            &kp F  &kp W          &kp R         &kp Y         &kp P
+&kp E         &kp I          &kp A         &kp O         &kp MINUS      &mt HOME LEFT_ARROW                 &mt END RIGHT_ARROW  &kp K  &kp T          &kp N         &kp S         &kp H
+&mt LSHIFT Z  &mtls LCTRL X  &mtls LALT C  &mtls LCMD V  &kp SEMICOLON  &kp TAB                             &kp ENTER            &kp G  &mtls RCTRL D  &mtls RALT M  &mtls RCMD J  &mt LSHIFT B
+                                           &kpls RCTRL   &kpls RALT     &kpls LCMD           &kp LANG1      &kp LANG2
+                                                         &moto 2 0      &moto 3 1            &kp BACKSPACE  &kp SPACE
             >;
         };
 
         Move {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
-&mo 5             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &mo 5
-&mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
-                                               &kpls LCTRL      &kpls LALT   &kpls LCMD             &msc SCRL_DOWN    &kp RS(TAB)
-                                                              &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&mo 5             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                             &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &mo 5
+&mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                              &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD           &msc SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1            &msc SCRL_UP    &kp TAB
             >;
         };
 
         Char {
             bindings = <
-&kp ESCAPE  &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE       &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp MINUS      &kp EQUAL  &kp ASTERISK
-&mo 5       &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5        &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp SEMICOLON  &kp SQT    &kp GRAVE
-&kp LSHIFT  &kpls LCTRL    &kpls LALT        &kpls LCMD       &none      &kp TAB                              &kp ENTER       &kp COMMA             &kp PERIOD             &kp BACKSLASH  &kp SLASH  &mt RSHIFT EXCLAMATION
-                                         &kpls LCTRL      &kpls LALT   &kpls LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
-                                                        &moto 2 0  &moto 3 1            &kp BACKSPACE   &kp SPACE
+&kp ESCAPE  &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mt CAPSLOCK DELETE                  &kp SPACE       &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp MINUS      &kp EQUAL  &kp ASTERISK
+&mo 5       &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                             &mkp MB5        &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp SEMICOLON  &kp SQT    &kp GRAVE
+&kp LSHIFT  &kpls LCTRL  &kpls LALT      &kpls LCMD     &none       &kp TAB                              &kp ENTER       &kp COMMA             &kp PERIOD             &kp BACKSLASH  &kp SLASH  &mt RSHIFT EXCLAMATION
+                                         &kpls LCTRL    &kpls LALT  &kpls LCMD           &kp LANGUAGE_1  &kp LANGUAGE_2
+                                                        &moto 2 0   &moto 3 1            &kp BACKSPACE   &kp SPACE
             >;
         };
 
         Num {
             bindings = <
-&kp ESC     &kp PAGE_UP     &kp UP_ARROW    &kp PAGE_DOWN    &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE       &kp SLASH     &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp MINUS
-&mo 5       &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &kp END    &mkp MB4                             &mkp MB5        &kp ASTERISK  &kp NUMBER_4  &kp N5        &kp NUMBER_6  &kp PLUS
-&kp LSHIFT  &kpls LCTRL       &kpls LALT        &kpls LCMD         &none      &kp TAB                              &kp ENTER       &kp NUMBER_0  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp PERIOD
-                                            &kpls LCTRL        &kpls LALT   &kpls LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
-                                                             &moto 2 0  &moto 3 1            &kp BACKSPACE   &kp SPACE
+&kp ESC     &kp PAGE_UP     &kp UP_ARROW    &kp PAGE_DOWN    &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE       &kp SLASH     &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp MINUS
+&mo 5       &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &kp END     &mkp MB4                               &mkp MB5        &kp ASTERISK  &kp NUMBER_4  &kp N5        &kp NUMBER_6  &kp PLUS
+&kp LSHIFT  &kpls LCTRL     &kpls LALT      &kpls LCMD       &none       &kp TAB                                &kp ENTER       &kp NUMBER_0  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp PERIOD
+                                            &kpls LCTRL      &kpls LALT  &kpls LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
+                                                             &moto 2 0   &moto 3 1              &kp BACKSPACE   &kp SPACE
             >;
         };
 
@@ -121,11 +121,11 @@
 
         Scroll {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
-&none             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &none
-&mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
-                                               &kpls LCTRL      &kpls LALT   &kpls LCMD             &msc SCRL_DOWN    &kp RS(TAB)
-                                                              &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&none             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                               &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &none
+&mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                                &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &msc SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1              &msc SCRL_UP    &kp TAB
             >;
         };
 
@@ -141,10 +141,9 @@
 
         Setting {
             bindings = <
-&none  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3
-&bt BT_SEL 4
+&none  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
 &none  &none  &none  &none  &none  &studio_unlock         &none         &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none  &none                  &tog_ls         &none         &none         &none         &bt BT_PRV    &bt BT_NXT
+&none  &none  &none  &none  &none  &none                  &tog_ls       &none         &none         &none         &bt BT_PRV    &bt BT_NXT
                      &none  &none  &none           &none  &none
                             &none  &none           &none  &none
             >;

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -71,9 +71,9 @@
 
         Default {
             bindings = <
-&mtls ESC Q     &kp L        &kp U       &kp COMMA   &kp PERIOD     &mtls CAPSLOCK DELETE                 &kp SPACE      &kp F  &kp W        &kp R       &kp Y       &kp P
-&kp E         &kp I        &kp A       &kp O       &kp MINUS      &mtls HOME LEFT_ARROW                 &mtls END RIGHT  &kp K  &kp T        &kp N       &kp S       &kp H
-&mtls LSHIFT Z  &mtls LCTRL X  &mtls LALT C  &mtls LCMD V  &kp SEMICOLON  &kp TAB                             &kp ENTER      &kp G  &mtls RCTRL D  &mtls RALT M  &mtls RCMD J  &mtls LSHIFT B
+&mt ESC Q     &kp L        &kp U       &kp COMMA   &kp PERIOD     &mt CAPSLOCK DELETE                 &kp SPACE      &kp F  &kp W        &kp R       &kp Y       &kp P
+&kp E         &kp I        &kp A       &kp O       &kp MINUS      &mt HOME LEFT_ARROW                 &mt END RIGHT  &kp K  &kp T        &kp N       &kp S       &kp H
+&mt LSHIFT Z  &mtls LCTRL X  &mtls LALT C  &mtls LCMD V  &kp SEMICOLON  &kp TAB                             &kp ENTER      &kp G  &mtls RCTRL D  &mtls RALT M  &mtls RCMD J  &mt LSHIFT B
                                        &kpls RCTRL   &kpls RALT       &kpls LCMD             &kp LANG1      &kp LANG2
                                                    &moto 2 0      &moto 3 1            &kp BACKSPACE  &kp SPACE
             >;
@@ -81,9 +81,9 @@
 
         Move {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
+&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
 &mo 5             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &mo 5
-&mtls LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
+&mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
                                                &kpls LCTRL      &kpls LALT   &kpls LCMD             &msc SCRL_DOWN    &kp RS(TAB)
                                                               &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
             >;
@@ -91,9 +91,9 @@
 
         Char {
             bindings = <
-&kp ESCAPE  &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE       &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp MINUS      &kp EQUAL  &kp ASTERISK
+&kp ESCAPE  &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE       &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp MINUS      &kp EQUAL  &kp ASTERISK
 &mo 5       &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5        &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp SEMICOLON  &kp SQT    &kp GRAVE
-&kp LSHIFT  &kpls LCTRL    &kpls LALT        &kpls LCMD       &none      &kp TAB                              &kp ENTER       &kp COMMA             &kp PERIOD             &kp BACKSLASH  &kp SLASH  &mtls RSHIFT EXCLAMATION
+&kp LSHIFT  &kpls LCTRL    &kpls LALT        &kpls LCMD       &none      &kp TAB                              &kp ENTER       &kp COMMA             &kp PERIOD             &kp BACKSLASH  &kp SLASH  &mt RSHIFT EXCLAMATION
                                          &kpls LCTRL      &kpls LALT   &kpls LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
                                                         &moto 2 0  &moto 3 1            &kp BACKSPACE   &kp SPACE
             >;
@@ -123,7 +123,7 @@
             bindings = <
 &kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
 &none             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &none
-&mtls LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
+&mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
                                                &kpls LCTRL      &kpls LALT   &kpls LCMD             &msc SCRL_DOWN    &kp RS(TAB)
                                                               &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
             >;

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -141,10 +141,10 @@
 
         Setting {
             bindings = <
-&tog_ls  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3
+&none  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3
 &bt BT_SEL 4
 &none  &none  &none  &none  &none  &studio_unlock         &none         &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none  &none                  &none         &none         &none         &none         &bt BT_PRV    &bt BT_NXT
+&none  &none  &none  &none  &none  &none                  &tog_ls         &none         &none         &none         &bt BT_PRV    &bt BT_NXT
                      &none  &none  &none           &none  &none
                             &none  &none           &none  &none
             >;

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -89,11 +89,11 @@
 
         Move {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mt CAPSLOCK DELETE                  &kp SPACE    &none  &mscls SCRL_RIGHT  &mscls SCRL_LEFT  &none       &none
 &mols 5           &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                             &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &mols 5
 &mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                              &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
-                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD           &msc SCRL_DOWN  &kp RS(TAB)
-                                                                &moto 2 0   &moto 3 1            &msc SCRL_UP    &kp TAB
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD           &mscls SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1            &mscls SCRL_UP    &kp TAB
             >;
         };
 
@@ -129,21 +129,21 @@
 
         ScrollMac {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &mscls SCRL_RIGHT  &mscls SCRL_LEFT  &none       &none
 &none             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                               &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &none
 &mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                                &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
-                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &msc SCRL_DOWN  &kp RS(TAB)
-                                                                &moto 2 0   &moto 3 1              &msc SCRL_UP    &kp TAB
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &mscls SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1              &mscls SCRL_UP    &kp TAB
             >;
         };
 
         ScrollWin {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
+&kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &mscls SCRL_RIGHT  &mscls SCRL_LEFT  &none       &none
 &none             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                               &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &none
 &mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                                &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
-                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &msc SCRL_DOWN  &kp RS(TAB)
-                                                                &moto 2 0   &moto 3 1              &msc SCRL_UP    &kp TAB
+                                                 &kpls LCTRL    &kpls LALT  &kpls LCMD             &mscls SCRL_DOWN  &kp RS(TAB)
+                                                                &moto 2 0   &moto 3 1              &mscls SCRL_UP    &kp TAB
             >;
         };
 

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -62,6 +62,11 @@
             #binding-cells = <2>;
             tapping-term-ms = <300>;
         };
+
+        // mols_demo: placeholder for layout shift momentary layer behavior
+        // mols_demo {
+        //     bindings = <&mols 6>; // TODO: Replace 6 with base layer, shifted layer defined in layout
+        // };
     };
 
     keymap {

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -159,9 +159,9 @@
 
         Setting {
             bindings = <
-&none  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-&none  &none  &none  &none  &none  &studio_unlock         &none         &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none  &none                  &tog_ls       &none         &none         &none         &bt BT_PRV    &bt BT_NXT
+&none  &none  &none  &none  &none  &bt BT_CLR             &to_ls 0      &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
+&none  &none  &none  &none  &none  &studio_unlock         &to_ls 1      &none         &none         &none         &none         &none
+&none  &none  &none  &none  &none  &out OUT_TOG           &tog_ls       &none         &none         &none         &bt BT_PRV    &bt BT_NXT
                      &none  &none  &none           &none  &none
                             &none  &none           &none  &none
             >;

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -90,7 +90,7 @@
         Move {
             bindings = <
 &kp ESCAPE        &kp PAGE_UP    &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME    &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none       &none
-&mo 5             &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                             &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &mo 5
+&mols 5           &kp LEFT       &kp DOWN_ARROW  &kp RIGHT      &kp END     &mkp MB4                             &mkp MB5     &none  &mkp MB1         &mkp MB2        &mkp MB3    &mols 5
 &mt LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C    &mtls LCMD V   &none       &kp TAB                              &kp ENTER    &none  &kpls RCTRL      &kpls RALT      &kpls RCMD  &kp RSHIFT
                                                  &kpls LCTRL    &kpls LALT  &kpls LCMD           &msc SCRL_DOWN  &kp RS(TAB)
                                                                 &moto 2 0   &moto 3 1            &msc SCRL_UP    &kp TAB

--- a/config/keymap.keymap
+++ b/config/keymap.keymap
@@ -3,6 +3,7 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/pointing.h>
+#include "../dts/layout_shift.dtsi"
 
 // ZMK用のキーマップ設定ファイル
 // レイヤー構成:
@@ -70,40 +71,40 @@
 
         Default {
             bindings = <
-&mt ESC Q     &kp L        &kp U       &kp COMMA   &kp PERIOD     &mt CAPSLOCK DELETE                 &kp SPACE      &kp F  &kp W        &kp R       &kp Y       &kp P
-&kp E         &kp I        &kp A       &kp O       &kp MINUS      &mt HOME LEFT_ARROW                 &mt END RIGHT  &kp K  &kp T        &kp N       &kp S       &kp H
-&mt LSHIFT Z  &mt LCTRL X  &mt LALT C  &mt LGUI V  &kp SEMICOLON  &kp TAB                             &kp ENTER      &kp G  &mt RCTRL D  &mt RALT M  &mt RGUI J  &mt LSHIFT B
-                                       &kp RCTRL   &kp RALT       &kp LCMD             &kp LANG1      &kp LANG2
+&mtls ESC Q     &kp L        &kp U       &kp COMMA   &kp PERIOD     &mtls CAPSLOCK DELETE                 &kp SPACE      &kp F  &kp W        &kp R       &kp Y       &kp P
+&kp E         &kp I        &kp A       &kp O       &kp MINUS      &mtls HOME LEFT_ARROW                 &mtls END RIGHT  &kp K  &kp T        &kp N       &kp S       &kp H
+&mtls LSHIFT Z  &mtls LCTRL X  &mtls LALT C  &mtls LCMD V  &kp SEMICOLON  &kp TAB                             &kp ENTER      &kp G  &mtls RCTRL D  &mtls RALT M  &mtls RCMD J  &mtls LSHIFT B
+                                       &kpls RCTRL   &kpls RALT       &kpls LCMD             &kp LANG1      &kp LANG2
                                                    &moto 2 0      &moto 3 1            &kp BACKSPACE  &kp SPACE
             >;
         };
 
         Move {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
+&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
 &mo 5             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &mo 5
-&mt LEFT_SHIFT Z  &mt LCTRL X  &mt LALT C      &mt LGUI V     &none      &kp TAB                              &kp ENTER    &none  &kp RCTRL       &kp RALT         &kp RGUI  &kp RSHIFT
-                                               &kp LCTRL      &kp LALT   &kp LCMD             &msc SCRL_DOWN    &kp RS(TAB)
+&mtls LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
+                                               &kpls LCTRL      &kpls LALT   &kpls LCMD             &msc SCRL_DOWN    &kp RS(TAB)
                                                               &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
             >;
         };
 
         Char {
             bindings = <
-&kp ESCAPE  &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE       &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp MINUS      &kp EQUAL  &kp ASTERISK
+&kp ESCAPE  &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE       &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp MINUS      &kp EQUAL  &kp ASTERISK
 &mo 5       &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5        &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp SEMICOLON  &kp SQT    &kp GRAVE
-&kp LSHIFT  &kp LCTRL    &kp LALT        &kp LCMD       &none      &kp TAB                              &kp ENTER       &kp COMMA             &kp PERIOD             &kp BACKSLASH  &kp SLASH  &mt RSHIFT EXCLAMATION
-                                         &kp LCTRL      &kp LALT   &kp LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
+&kp LSHIFT  &kpls LCTRL    &kpls LALT        &kpls LCMD       &none      &kp TAB                              &kp ENTER       &kp COMMA             &kp PERIOD             &kp BACKSLASH  &kp SLASH  &mtls RSHIFT EXCLAMATION
+                                         &kpls LCTRL      &kpls LALT   &kpls LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
                                                         &moto 2 0  &moto 3 1            &kp BACKSPACE   &kp SPACE
             >;
         };
 
         Num {
             bindings = <
-&kp ESC     &kp PAGE_UP     &kp UP_ARROW    &kp PAGE_DOWN    &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE       &kp SLASH     &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp MINUS
+&kp ESC     &kp PAGE_UP     &kp UP_ARROW    &kp PAGE_DOWN    &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE       &kp SLASH     &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp MINUS
 &mo 5       &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &kp END    &mkp MB4                             &mkp MB5        &kp ASTERISK  &kp NUMBER_4  &kp N5        &kp NUMBER_6  &kp PLUS
-&kp LSHIFT  &kp LCTRL       &kp LALT        &kp LGUI         &none      &kp TAB                              &kp ENTER       &kp NUMBER_0  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp PERIOD
-                                            &kp LCTRL        &kp LALT   &kp LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
+&kp LSHIFT  &kpls LCTRL       &kpls LALT        &kpls LCMD         &none      &kp TAB                              &kp ENTER       &kp NUMBER_0  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp PERIOD
+                                            &kpls LCTRL        &kpls LALT   &kpls LCMD             &kp LANGUAGE_1  &kp LANGUAGE_2
                                                              &moto 2 0  &moto 3 1            &kp BACKSPACE   &kp SPACE
             >;
         };
@@ -120,10 +121,10 @@
 
         Scroll {
             bindings = <
-&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mt CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
+&kp ESCAPE        &kp PAGE_UP  &kp UP_ARROW    &kp PAGE_DOWN  &kp HOME   &mtls CAPSLOCK DELETE                  &kp SPACE    &none  &msc SCRL_RIGHT  &msc SCRL_LEFT  &none     &none
 &none             &kp LEFT     &kp DOWN_ARROW  &kp RIGHT      &kp END    &mkp MB4                             &mkp MB5     &none  &mkp MB1        &mkp MB2         &mkp MB3  &none
-&mt LEFT_SHIFT Z  &mt LCTRL X  &mt LALT C      &mt LGUI V     &none      &kp TAB                              &kp ENTER    &none  &kp RCTRL       &kp RALT         &kp RGUI  &kp RSHIFT
-                                               &kp LCTRL      &kp LALT   &kp LCMD             &msc SCRL_DOWN    &kp RS(TAB)
+&mtls LEFT_SHIFT Z  &mtls LCTRL X  &mtls LALT C      &mtls LCMD V     &none      &kp TAB                              &kp ENTER    &none  &kpls RCTRL       &kpls RALT         &kpls RCMD  &kp RSHIFT
+                                               &kpls LCTRL      &kpls LALT   &kpls LCMD             &msc SCRL_DOWN    &kp RS(TAB)
                                                               &moto 2 0  &moto 3 1            &msc SCRL_UP  &kp TAB
             >;
         };
@@ -140,7 +141,8 @@
 
         Setting {
             bindings = <
-&none  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
+&tog_ls  &none  &none  &none  &none  &bt BT_CLR             &out OUT_TOG  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3
+&bt BT_SEL 4
 &none  &none  &none  &none  &none  &studio_unlock         &none         &none         &none         &none         &none         &none
 &none  &none  &none  &none  &none  &none                  &none         &none         &none         &none         &bt BT_PRV    &bt BT_NXT
                      &none  &none  &none           &none  &none

--- a/dts/bindings/behaviors/zmk,behavior-layout-shift-key-press.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-shift-key-press.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout shift custom key press behavior that maps keycodes according to the current layout shift state
+
+compatible: "zmk,behavior-layout-shift-key-press"
+
+include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-layout-shift-to.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-shift-to.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout shift set behavior
+
+compatible: "zmk,behavior-layout-shift-to"
+
+include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-layout-shift-toggle.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-shift-toggle.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout shift toggle behavior
+
+compatible: "zmk,behavior-layout-shift-toggle"
+
+include: zero_param.yaml
+
+properties:
+  toggle-mode:
+    type: string
+    required: false
+    default: "flip"
+    enum:
+      - "on"
+      - "off" 
+      - "flip"
+    description: |
+      Toggle mode for the layout shift behavior:
+      - "on": Turn layout shift on
+      - "off": Turn layout shift off
+      - "flip": Toggle layout shift state

--- a/dts/bindings/behaviors/zmk,behavior-mols.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-mols.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Momentary layer behavior that selects the target layer based on the current layout shift state
+
+compatible: "zmk,behavior-mols"
+
+include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-mscls.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-mscls.yaml
@@ -1,0 +1,11 @@
+description: Layout shift-aware mouse scroll behavior that maps scroll direction based on the current layout shift state
+
+compatible: "zmk,behavior-mscls"
+
+include: one_param.yaml
+
+properties:
+  msc:
+    type: phandle
+    required: true
+    description: Mouse scroll device used to send scroll events

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* ZMK Layout Shift Module */
+
+#include <dt-bindings/zmk/keys.h>
+
+/ {
+    behaviors {
+        // Layout-aware key press behavior alias
+        kpls: layout_shift_key_press {
+            compatible = "zmk,behavior-layout-shift-key-press";
+            #binding-cells = <1>;
+            label = "LAYOUT_SHIFT_KEY_PRESS";
+            display-name = "Key Press with Layout Shift";
+        };
+
+        // Layout-aware mod-tap behavior alias
+        mtls: layout_shift_mod_tap {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "hold-preferred";
+            tapping-term-ms = <200>;
+            bindings = <&kpls>, <&kpls>;
+            display-name = "Mod-Tap with Layout Shift";
+        };
+
+        // Layout shift toggle behaviors
+        tog_ls: toggle_layout_shift {
+            compatible = "zmk,behavior-layout-shift-toggle";
+            #binding-cells = <0>;
+            toggle-mode = "flip";
+            label = "LAYOUT_SHIFT_TOGGLE";
+            display-name = "Toggle Layout Shift";
+        };
+
+        tog_ls_on: toggle_layout_shift_on {
+            compatible = "zmk,behavior-layout-shift-toggle";
+            #binding-cells = <0>;
+            toggle-mode = "on";
+            label = "LAYOUT_SHIFT_TOGGLE_ON";
+            display-name = "Toggle Layout Shift On";
+        };
+
+        tog_ls_off: toggle_layout_shift_off {
+            compatible = "zmk,behavior-layout-shift-toggle";
+            #binding-cells = <0>;
+            toggle-mode = "off";
+            label = "LAYOUT_SHIFT_TOGGLE_OFF";
+            display-name = "Toggle Layout Shift Off";
+        };
+    };
+};

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -9,56 +9,72 @@
 #include <dt-bindings/zmk/keys.h>
 
 / {
-    behaviors {
-        // Layout-aware key press behavior alias
-        kpls: layout_shift_key_press {
-            compatible = "zmk,behavior-layout-shift-key-press";
-            #binding-cells = <1>;
-            label = "LAYOUT_SHIFT_KEY_PRESS";
-            display-name = "Key Press with Layout Shift";
-        };
-
-        // Layout-aware mod-tap behavior alias
-        mtls: layout_shift_mod_tap {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "hold-preferred";
-            tapping-term-ms = <200>;
-            bindings = <&kpls>, <&kpls>;
-            display-name = "Mod-Tap with Layout Shift";
-        };
-
-        // Layout-aware momentary layer behavior alias
-        mols: layout_shift_momentary_layer {
-            compatible = "zmk,behavior-mols";
-            #binding-cells = <1>;
-            label = "LAYOUT_SHIFT_MO";
-            display-name = "Momentary Layer with Layout Shift";
-        };
-
-        // Layout shift toggle behaviors
-        tog_ls: toggle_layout_shift {
-            compatible = "zmk,behavior-layout-shift-toggle";
-            #binding-cells = <0>;
-            toggle-mode = "flip";
-            label = "LAYOUT_SHIFT_TOGGLE";
-            display-name = "Toggle Layout Shift";
-        };
-
-        tog_ls_on: toggle_layout_shift_on {
-            compatible = "zmk,behavior-layout-shift-toggle";
-            #binding-cells = <0>;
-            toggle-mode = "on";
-            label = "LAYOUT_SHIFT_TOGGLE_ON";
-            display-name = "Toggle Layout Shift On";
-        };
-
-        tog_ls_off: toggle_layout_shift_off {
-            compatible = "zmk,behavior-layout-shift-toggle";
-            #binding-cells = <0>;
-            toggle-mode = "off";
-            label = "LAYOUT_SHIFT_TOGGLE_OFF";
-            display-name = "Toggle Layout Shift Off";
-        };
+  behaviors {
+  // Layout-aware key press behavior alias
+  kpls:
+    layout_shift_key_press {
+      compatible = "zmk,behavior-layout-shift-key-press";
+#binding-cells = <1>;
+      label = "LAYOUT_SHIFT_KEY_PRESS";
+      display-name = "Key Press with Layout Shift";
     };
+
+  // Layout-aware mod-tap behavior alias
+  mtls:
+    layout_shift_mod_tap {
+      compatible = "zmk,behavior-hold-tap";
+#binding-cells = <2>;
+      flavor = "hold-preferred";
+      tapping-term-ms = <200>;
+      bindings = <&kpls>, <&kpls>;
+      display-name = "Mod-Tap with Layout Shift";
+    };
+
+  // Layout-aware momentary layer behavior alias
+  mols:
+    layout_shift_momentary_layer {
+      compatible = "zmk,behavior-mols";
+#binding-cells = <1>;
+      label = "LAYOUT_SHIFT_MO";
+      display-name = "Momentary Layer with Layout Shift";
+    };
+
+  // Layout-aware mouse scroll behavior alias
+  mscls:
+    layout_shift_mouse_scroll {
+      compatible = "zmk,behavior-mscls";
+#binding-cells = <1>;
+      msc = <&msc>;
+      label = "LAYOUT_SHIFT_MOUSE_SCROLL";
+      display-name = "Mouse Scroll with Layout Shift";
+    };
+
+  // Layout shift toggle behaviors
+  tog_ls:
+    toggle_layout_shift {
+      compatible = "zmk,behavior-layout-shift-toggle";
+#binding-cells = <0>;
+      toggle-mode = "flip";
+      label = "LAYOUT_SHIFT_TOGGLE";
+      display-name = "Toggle Layout Shift";
+    };
+
+  tog_ls_on:
+    toggle_layout_shift_on {
+      compatible = "zmk,behavior-layout-shift-toggle";
+#binding-cells = <0>;
+      toggle-mode = "on";
+      label = "LAYOUT_SHIFT_TOGGLE_ON";
+      display-name = "Toggle Layout Shift On";
+    };
+
+  tog_ls_off:
+    toggle_layout_shift_off {
+      compatible = "zmk,behavior-layout-shift-toggle";
+#binding-cells = <0>;
+      toggle-mode = "off";
+      label = "LAYOUT_SHIFT_TOGGLE_OFF";
+      display-name = "Toggle Layout Shift Off";
+    };
+  };
 };

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -49,6 +49,15 @@
       display-name = "Mouse Scroll with Layout Shift";
     };
 
+  // Layout shift set behavior alias
+  to_ls:
+    layout_shift_to {
+      compatible = "zmk,behavior-layout-shift-to";
+#binding-cells = <1>;
+      label = "LAYOUT_SHIFT_TO";
+      display-name = "Set Layout Shift";
+    };
+
   // Layout shift toggle behaviors
   tog_ls:
     toggle_layout_shift {

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -28,6 +28,14 @@
             display-name = "Mod-Tap with Layout Shift";
         };
 
+        // Layout-aware momentary layer behavior alias
+        mols: layout_shift_momentary_layer {
+            compatible = "zmk,behavior-mols";
+            #binding-cells = <1>;
+            label = "LAYOUT_SHIFT_MO";
+            display-name = "Momentary Layer with Layout Shift";
+        };
+
         // Layout shift toggle behaviors
         tog_ls: toggle_layout_shift {
             compatible = "zmk,behavior-layout-shift-toggle";

--- a/dts/layout_shift_kp_override.dtsi
+++ b/dts/layout_shift_kp_override.dtsi
@@ -1,0 +1,22 @@
+// Layout Shift Overlay - Replaces &kp behavior with custom implementation
+// This file should be included in keyboard config to override &kp behavior
+
+#include "layout_shift.dtsi"
+
+/ {
+    behaviors {
+        // Keep the original key_press behavior for ZMK core components
+        original_key_press: original_key_press {
+            compatible = "zmk,behavior-key-press";
+            #binding-cells = <1>;
+            label = "KEY_PRESS";
+        };
+
+        // Override the existing &kp behavior to use our custom implementation
+        kp: key_press {
+            compatible = "zmk,behavior-layout-shift-key-press";
+            #binding-cells = <1>;
+            label = "LAYOUT_SHIFT_KEY_PRESS";
+        };
+    };
+};

--- a/src/behavior_layout_shift_key_press.c
+++ b/src/behavior_layout_shift_key_press.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_layout_shift_key_press
 
 #include <drivers/behavior.h>

--- a/src/behavior_layout_shift_key_press.c
+++ b/src/behavior_layout_shift_key_press.c
@@ -1,0 +1,323 @@
+#define DT_DRV_COMPAT zmk_behavior_layout_shift_key_press
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <drivers/behavior.h>
+#include <zmk/behavior.h>
+#include <zmk/event_manager.h>
+#include <zmk/events/keycode_state_changed.h>
+#include <zmk/hid.h>
+#include <zmk/keys.h>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/modifiers.h>
+#include <dt-bindings/zmk/hid_usage.h>
+#include <dt-bindings/zmk/hid_usage_pages.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+// External function to check layout shift state
+extern bool zmk_layout_shift_is_active(void);
+
+// Keycode mapping structure
+struct keycode_mapping {
+    uint32_t us_keycode;
+    uint32_t target_keycode;
+    zmk_mod_flags_t optional_modifiers;  // Bitmask of modifiers that are optional during matching
+};
+
+// Convenient modifier mask definitions (defined before including layouts)
+#define OPTIONAL_SHIFT  (MOD_LSFT | MOD_RSFT)
+#define OPTIONAL_CTRL   (MOD_LCTL | MOD_RCTL)
+#define OPTIONAL_ALT    (MOD_LALT | MOD_RALT)
+#define OPTIONAL_GUI    (MOD_LGUI | MOD_RGUI)
+#define OPTIONAL_ALL    (0xFF)
+#define OPTIONAL_NONE   (0)
+
+// Include all layout definitions (with conditional compilation)
+#include "layouts/index.h"
+
+#define LAYOUT_MAP_SIZE (sizeof(layout_map) / sizeof(layout_map[0]))
+
+
+// Function to lookup mapped keycode from input keycode with optional modifier support
+// Returns the mapped keycode, and optionally stores the matched layout entry index
+static uint32_t lookup_mapped_keycode(uint32_t input_keycode, int *matched_index) {
+    // Only apply mapping if layout shift is active
+    if (!zmk_layout_shift_is_active()) {
+        return input_keycode;
+    }
+
+    // Get current explicit modifier state and any modifiers embedded in the keycode
+    zmk_mod_flags_t current_mods = zmk_hid_get_explicit_mods();
+    zmk_mod_flags_t keycode_mods = SELECT_MODS(input_keycode);
+
+    // Combine explicit modifiers with modifiers from the keycode
+    zmk_mod_flags_t total_input_mods = current_mods | keycode_mods;
+
+    // Get the base keycode without modifiers for comparison
+    uint32_t base_input = STRIP_MODS(input_keycode);
+
+    // Look up in mapping table with optional modifier support
+    for (size_t i = 0; i < LAYOUT_MAP_SIZE; i++) {
+        uint32_t base_us = STRIP_MODS(layout_map[i].us_keycode);
+        zmk_mod_flags_t us_mods = SELECT_MODS(layout_map[i].us_keycode);
+
+        // Check if base keycodes match
+        if (base_input == base_us) {
+            // Check if non-optional modifiers match
+            zmk_mod_flags_t required_mods = us_mods & ~layout_map[i].optional_modifiers;
+            zmk_mod_flags_t input_required_mods = total_input_mods & ~layout_map[i].optional_modifiers;
+
+            if (required_mods == input_required_mods) {
+                // Match found! Apply target keycode with layout-defined modifiers
+                uint32_t target_base = STRIP_MODS(layout_map[i].target_keycode);
+                zmk_mod_flags_t target_mods = SELECT_MODS(layout_map[i].target_keycode);
+
+                // Combine target modifiers with non-optional input modifiers
+                zmk_mod_flags_t final_mods = target_mods | (total_input_mods & layout_map[i].optional_modifiers);
+
+                uint32_t result = (final_mods != 0) ? APPLY_MODS(final_mods, target_base) : target_base;
+
+                // Store the matched index if caller wants it
+                if (matched_index != NULL) {
+                    *matched_index = i;
+                }
+
+                LOG_DBG("LAYOUT_SHIFT: Mapping %08X -> %08X (input_mods: %02X, required: %02X, target_mods: %02X, final: %02X)",
+                        input_keycode, result, total_input_mods, required_mods, target_mods, final_mods);
+                return result;
+            }
+        }
+    }
+
+    // If no mapping found, return original keycode
+    if (matched_index != NULL) {
+        *matched_index = -1;  // Indicate no match found
+    }
+    LOG_DBG("LAYOUT_SHIFT: No mapping found for %08X", input_keycode);
+    return input_keycode;
+}
+
+// Storage for tracking key press/release mappings
+#define MAX_PRESSED_KEYS 16
+
+struct key_mapping_entry {
+    uint32_t original_keycode;
+    uint32_t mapped_keycode;
+    bool active;
+};
+
+struct behavior_layout_shift_key_press_data {
+    struct key_mapping_entry pressed_keys[MAX_PRESSED_KEYS];
+    zmk_mod_flags_t currently_masked_mods;
+};
+
+struct behavior_layout_shift_key_press_config {};
+
+// Helper function to mask unwanted modifiers
+static void mask_unwanted_modifiers(struct behavior_layout_shift_key_press_data *data,
+                                   zmk_mod_flags_t optional_mods, zmk_mod_flags_t mapped_keycode,
+                                   zmk_mod_flags_t current_mods) {
+    // Get modifiers that are defined in the mapped keycode
+    zmk_mod_flags_t mapped_mods = SELECT_MODS(mapped_keycode);
+
+    // Calculate unwanted modifiers:
+    // - NOT in optional_modifiers (required modifiers)
+    // - NOT in mapped_keycode modifiers (not needed for output)
+    // - BUT in current explicit modifiers (currently active)
+    zmk_mod_flags_t required_mods = ~optional_mods;  // Modifiers that are NOT optional
+    zmk_mod_flags_t not_needed_mods = ~mapped_mods;  // Modifiers NOT in mapped keycode
+    zmk_mod_flags_t unwanted_mods = required_mods & not_needed_mods & current_mods;
+
+    if (unwanted_mods != 0 && unwanted_mods != data->currently_masked_mods) {
+        // Clear any previously masked modifiers
+        if (data->currently_masked_mods != 0) {
+            zmk_hid_masked_modifiers_clear();
+        }
+
+        // Apply new modifier mask
+        zmk_hid_masked_modifiers_set(unwanted_mods);
+        data->currently_masked_mods = unwanted_mods;
+
+        LOG_DBG("LAYOUT_SHIFT: Masking unwanted modifiers: %02X (optional: %02X, mapped: %02X, current: %02X)",
+                unwanted_mods, optional_mods, mapped_mods, current_mods);
+    }
+}
+
+// Helper function to clear modifier mask
+static void clear_modifier_mask(struct behavior_layout_shift_key_press_data *data) {
+    if (data->currently_masked_mods != 0) {
+        zmk_hid_masked_modifiers_clear();
+        LOG_DBG("LAYOUT_SHIFT: Cleared modifier mask: %02X", data->currently_masked_mods);
+        data->currently_masked_mods = 0;
+    }
+}
+
+// Helper functions for key mapping storage
+static int store_key_mapping(struct behavior_layout_shift_key_press_data *data,
+                            uint32_t original_keycode, uint32_t mapped_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (!data->pressed_keys[i].active) {
+            data->pressed_keys[i].original_keycode = original_keycode;
+            data->pressed_keys[i].mapped_keycode = mapped_keycode;
+            data->pressed_keys[i].active = true;
+            return 0;
+        }
+    }
+    LOG_WRN("LAYOUT_SHIFT: No free slots to store key mapping");
+    return -ENOMEM;
+}
+
+static uint32_t get_stored_mapping(struct behavior_layout_shift_key_press_data *data,
+                                  uint32_t original_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (data->pressed_keys[i].active &&
+            data->pressed_keys[i].original_keycode == original_keycode) {
+            return data->pressed_keys[i].mapped_keycode;
+        }
+    }
+    return 0; // Not found
+}
+
+static int remove_key_mapping(struct behavior_layout_shift_key_press_data *data,
+                             uint32_t original_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (data->pressed_keys[i].active &&
+            data->pressed_keys[i].original_keycode == original_keycode) {
+            data->pressed_keys[i].active = false;
+            return 0;
+        }
+    }
+    return -ENOENT;
+}
+
+static int on_layout_shift_key_press_binding_pressed(struct zmk_behavior_binding *binding,
+                                                    struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    struct behavior_layout_shift_key_press_data *data = dev->data;
+
+    uint32_t original_keycode = binding->param1;
+    int matched_layout_index = -1;
+    uint32_t mapped_keycode = lookup_mapped_keycode(original_keycode, &matched_layout_index);
+
+    LOG_DBG("LAYOUT_SHIFT: Input keycode 0x%08X -> Mapped keycode 0x%08X", original_keycode, mapped_keycode);
+
+    // If layout shift is active and mapping occurred, handle unwanted modifier masking
+    if (zmk_layout_shift_is_active() && mapped_keycode != original_keycode && matched_layout_index >= 0) {
+        zmk_mod_flags_t current_mods = zmk_hid_get_explicit_mods();
+        zmk_mod_flags_t keycode_mods = SELECT_MODS(original_keycode);
+        zmk_mod_flags_t total_mods = current_mods | keycode_mods;
+
+        // Use the already found layout entry
+        mask_unwanted_modifiers(data, layout_map[matched_layout_index].optional_modifiers, mapped_keycode, total_mods);
+    }
+
+    // Store the mapping for use during release
+    int ret = store_key_mapping(data, original_keycode, mapped_keycode);
+    if (ret < 0) {
+        LOG_ERR("LAYOUT_SHIFT: Failed to store key mapping: %d", ret);
+    }
+
+    // Raise the mapped keycode event
+    return raise_zmk_keycode_state_changed_from_encoded(
+        mapped_keycode,
+        true,  // pressed
+        event.timestamp
+    );
+}
+
+static int on_layout_shift_key_press_binding_released(struct zmk_behavior_binding *binding,
+                                                     struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    struct behavior_layout_shift_key_press_data *data = dev->data;
+
+    uint32_t original_keycode = binding->param1;
+    uint32_t mapped_keycode;
+
+    // Try to get the stored mapping first
+    uint32_t stored_mapping = get_stored_mapping(data, original_keycode);
+    if (stored_mapping != 0) {
+        mapped_keycode = stored_mapping;
+        LOG_DBG("LAYOUT_SHIFT: Using stored mapping for release 0x%08X -> 0x%08X",
+                original_keycode, mapped_keycode);
+
+        // Remove the mapping from storage
+        remove_key_mapping(data, original_keycode);
+    } else {
+        // Fall back to recalculating if no stored mapping found
+        mapped_keycode = lookup_mapped_keycode(original_keycode, NULL);
+        LOG_DBG("LAYOUT_SHIFT: No stored mapping found, recalculating 0x%08X -> 0x%08X",
+                original_keycode, mapped_keycode);
+    }
+
+    LOG_DBG("LAYOUT_SHIFT: Released input keycode 0x%08X -> Mapped keycode 0x%08X", original_keycode, mapped_keycode);
+
+    // Clear modifier mask when key is released
+    // This ensures that modifier masking is only active while layout-shifted keys are pressed
+    clear_modifier_mask(data);
+
+    // Release the mapped keycode
+    return raise_zmk_keycode_state_changed_from_encoded(
+        mapped_keycode,
+        false, // released
+        event.timestamp
+    );
+}
+
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+static const struct behavior_parameter_value_metadata keycode_value_metadata[] = {
+    {
+        .display_name = "Keycode",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_HID_USAGE,
+    },
+};
+
+static const struct behavior_parameter_metadata_set keycode_parameter_set = {
+    .param1_values = keycode_value_metadata,
+    .param1_values_len = ARRAY_SIZE(keycode_value_metadata),
+};
+
+static const struct behavior_parameter_metadata_set metadata_sets[] = {keycode_parameter_set};
+
+static const struct behavior_parameter_metadata layout_shift_key_press_parameter_metadata = {
+    .sets_len = ARRAY_SIZE(metadata_sets),
+    .sets = metadata_sets,
+};
+#endif
+
+static const struct behavior_driver_api behavior_layout_shift_key_press_driver_api = {
+    .binding_pressed = on_layout_shift_key_press_binding_pressed,
+    .binding_released = on_layout_shift_key_press_binding_released,
+    .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .parameter_metadata = &layout_shift_key_press_parameter_metadata,
+#endif
+};
+
+static int layout_shift_key_press_init(const struct device *dev) {
+    struct behavior_layout_shift_key_press_data *data =
+        (struct behavior_layout_shift_key_press_data *)dev->data;
+
+    // Initialize the pressed keys storage
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        data->pressed_keys[i].active = false;
+    }
+
+    // Initialize modifier masking state
+    data->currently_masked_mods = 0;
+
+    LOG_INF("Layout Shift Behavior Initialized");
+    return 0;
+}
+
+// Define behavior instance only if devicetree node exists
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+static struct behavior_layout_shift_key_press_data behavior_layout_shift_key_press_data_0 = {};
+static const struct behavior_layout_shift_key_press_config behavior_layout_shift_key_press_config_0 = {};
+
+BEHAVIOR_DT_INST_DEFINE(0, layout_shift_key_press_init, NULL,
+                        &behavior_layout_shift_key_press_data_0, &behavior_layout_shift_key_press_config_0,
+                        POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_layout_shift_key_press_driver_api);
+#endif

--- a/src/behavior_layout_shift_mouse_scroll.c
+++ b/src/behavior_layout_shift_mouse_scroll.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_mscls
 
 #include "layouts/layout_common.h"

--- a/src/behavior_layout_shift_mouse_scroll.c
+++ b/src/behavior_layout_shift_mouse_scroll.c
@@ -1,0 +1,83 @@
+#define DT_DRV_COMPAT zmk_behavior_mscls
+
+#include "layouts/layout_common.h"
+#include <drivers/behavior.h>
+#include <dt-bindings/zmk/pointing.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zmk/behavior.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+extern bool zmk_layout_shift_is_active(void);
+
+#define DEFINE_MSC_MAPPING
+#include "layouts/index.h"
+#undef DEFINE_MSC_MAPPING
+
+#ifdef MSC_MAP_DEFINED
+#define MSC_MAP_SIZE (sizeof(msc_map) / sizeof(msc_map[0]))
+#else
+#define MSC_MAP_SIZE 0
+static const struct msc_mapping msc_map[0];
+#endif
+
+struct behavior_mscls_config {
+  const struct device *msc_dev;
+};
+
+static uint32_t lookup_mapped_msc(uint32_t code) {
+  if (!zmk_layout_shift_is_active()) {
+    return code;
+  }
+  for (size_t i = 0; i < MSC_MAP_SIZE; i++) {
+    if (msc_map[i].base == code) {
+      return msc_map[i].shifted;
+    }
+  }
+  return code;
+}
+
+extern int behavior_input_two_axis_adjust_speed(const struct device *dev,
+                                                int16_t dx, int16_t dy);
+
+static int mscls_binding_pressed(struct zmk_behavior_binding *binding,
+                                 struct zmk_behavior_binding_event event) {
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  const struct behavior_mscls_config *cfg = dev->config;
+
+  uint32_t mapped = lookup_mapped_msc(binding->param1);
+  int16_t x = MOVE_X_DECODE(mapped);
+  int16_t y = MOVE_Y_DECODE(mapped);
+  behavior_input_two_axis_adjust_speed(cfg->msc_dev, x, y);
+  return 0;
+}
+
+static int mscls_binding_released(struct zmk_behavior_binding *binding,
+                                  struct zmk_behavior_binding_event event) {
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  const struct behavior_mscls_config *cfg = dev->config;
+
+  uint32_t mapped = lookup_mapped_msc(binding->param1);
+  int16_t x = MOVE_X_DECODE(mapped);
+  int16_t y = MOVE_Y_DECODE(mapped);
+  behavior_input_two_axis_adjust_speed(cfg->msc_dev, -x, -y);
+  return 0;
+}
+
+static const struct behavior_driver_api behavior_mscls_driver_api = {
+    .binding_pressed = mscls_binding_pressed,
+    .binding_released = mscls_binding_released,
+};
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define MSCLS_INST(n)                                                          \
+  static const struct behavior_mscls_config behavior_mscls_config_##n = {      \
+      .msc_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, msc)),                       \
+  };                                                                           \
+  BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, &behavior_mscls_config_##n,     \
+                          POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,    \
+                          &behavior_mscls_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MSCLS_INST)
+#endif

--- a/src/behavior_layout_shift_to.c
+++ b/src/behavior_layout_shift_to.c
@@ -1,0 +1,53 @@
+#define DT_DRV_COMPAT zmk_behavior_layout_shift_to
+
+#include <drivers/behavior.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zmk/behavior.h>
+#include <zmk/event_manager.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+// External function to set layout shift state
+extern void zmk_layout_shift_set_active(bool active);
+
+struct behavior_layout_shift_to_config {};
+struct behavior_layout_shift_to_data {};
+
+static int
+on_layout_shift_to_binding_pressed(struct zmk_behavior_binding *binding,
+                                   struct zmk_behavior_binding_event event) {
+  bool state = binding->param1 != 0;
+  zmk_layout_shift_set_active(state);
+  return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int
+on_layout_shift_to_binding_released(struct zmk_behavior_binding *binding,
+                                    struct zmk_behavior_binding_event event) {
+  return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api behavior_layout_shift_to_driver_api = {
+    .binding_pressed = on_layout_shift_to_binding_pressed,
+    .binding_released = on_layout_shift_to_binding_released,
+    .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .get_parameter_metadata = zmk_behavior_get_empty_param_metadata,
+#endif
+};
+
+static int layout_shift_to_init(const struct device *dev) { return 0; }
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define LAYOUT_SHIFT_TO_INST(n)                                                \
+  static struct behavior_layout_shift_to_data                                  \
+      behavior_layout_shift_to_data_##n = {};                                  \
+  BEHAVIOR_DT_INST_DEFINE(n, layout_shift_to_init, NULL,                       \
+                          &behavior_layout_shift_to_data_##n, NULL,            \
+                          POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,    \
+                          &behavior_layout_shift_to_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(LAYOUT_SHIFT_TO_INST)
+#endif

--- a/src/behavior_layout_shift_to.c
+++ b/src/behavior_layout_shift_to.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_layout_shift_to
 
 #include <drivers/behavior.h>

--- a/src/behavior_layout_shift_toggle.c
+++ b/src/behavior_layout_shift_toggle.c
@@ -1,0 +1,143 @@
+#define DT_DRV_COMPAT zmk_behavior_layout_shift_toggle
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
+#include <string.h>
+#include <drivers/behavior.h>
+#include <zmk/behavior.h>
+#include <zmk/event_manager.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+enum toggle_mode {
+    TOGGLE_MODE_ON,
+    TOGGLE_MODE_OFF,
+    TOGGLE_MODE_FLIP
+};
+
+struct behavior_layout_shift_toggle_config {
+    enum toggle_mode toggle_mode;
+};
+
+struct behavior_layout_shift_toggle_data {};
+
+// Global layout shift state
+static bool layout_shift_active = false;
+
+#if IS_ENABLED(CONFIG_LAYOUT_SHIFT_PERSISTENT_STATE)
+static void layout_shift_save_work_handler(struct k_work *work) {
+    settings_save_one("layout_shift/state", &layout_shift_active, sizeof(layout_shift_active));
+    LOG_DBG("Saved layout shift state: %d", layout_shift_active);
+}
+
+static struct k_work_delayable layout_shift_save_work;
+
+static int layout_shift_settings_load_cb(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg) {
+    const char *next;
+    if (settings_name_steq(name, "state", &next) && !next) {
+        if (len != sizeof(layout_shift_active)) {
+            return -EINVAL;
+        }
+
+        int rc = read_cb(cb_arg, &layout_shift_active, sizeof(layout_shift_active));
+        if (rc >= 0) {
+            LOG_INF("Loaded layout shift state: %d", layout_shift_active);
+        }
+        return MIN(rc, 0);
+    }
+    return -ENOENT;
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(layout_shift, "layout_shift", NULL, layout_shift_settings_load_cb, NULL, NULL);
+#endif // IS_ENABLED(CONFIG_LAYOUT_SHIFT_PERSISTENT_STATE)
+
+// Function to get current layout shift state
+bool zmk_layout_shift_is_active(void) {
+    return layout_shift_active;
+}
+
+// Function to set layout shift state
+void zmk_layout_shift_set_active(bool active) {
+    if (layout_shift_active != active) {
+        layout_shift_active = active;
+        LOG_INF("Layout shift %s", active ? "activated" : "deactivated");
+        
+#if IS_ENABLED(CONFIG_LAYOUT_SHIFT_PERSISTENT_STATE)
+        // Debounce saving to flash to reduce wear
+        k_work_reschedule(&layout_shift_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
+#endif
+    }
+}
+
+// Function to toggle layout shift state
+void zmk_layout_shift_toggle(void) {
+    zmk_layout_shift_set_active(!layout_shift_active);
+}
+
+static int on_layout_shift_toggle_binding_pressed(struct zmk_behavior_binding *binding,
+                                                 struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    const struct behavior_layout_shift_toggle_config *config = dev->config;
+
+    switch (config->toggle_mode) {
+        case TOGGLE_MODE_ON:
+            zmk_layout_shift_set_active(true);
+            break;
+        case TOGGLE_MODE_OFF:
+            zmk_layout_shift_set_active(false);
+            break;
+        case TOGGLE_MODE_FLIP:
+            zmk_layout_shift_toggle();
+            break;
+    }
+
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int on_layout_shift_toggle_binding_released(struct zmk_behavior_binding *binding,
+                                                  struct zmk_behavior_binding_event event) {
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api behavior_layout_shift_toggle_driver_api = {
+    .binding_pressed = on_layout_shift_toggle_binding_pressed,
+    .binding_released = on_layout_shift_toggle_binding_released,
+    .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .get_parameter_metadata = zmk_behavior_get_empty_param_metadata,
+#endif
+};
+
+static int layout_shift_toggle_init(const struct device *dev) {
+    layout_shift_active = false;
+    
+#if IS_ENABLED(CONFIG_LAYOUT_SHIFT_PERSISTENT_STATE)
+    k_work_init_delayable(&layout_shift_save_work, layout_shift_save_work_handler);
+#endif
+    
+    LOG_INF("Layout Shift Toggle Behavior Initialized!");
+    return 0;
+}
+
+#define TOGGLE_MODE_FROM_STR(str) \
+    (strcmp(str, "on") == 0 ? TOGGLE_MODE_ON : \
+     strcmp(str, "off") == 0 ? TOGGLE_MODE_OFF : \
+     TOGGLE_MODE_FLIP)
+
+// Only define behavior instances if devicetree nodes exist
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define LAYOUT_SHIFT_TOGGLE_INST(n) \
+    static struct behavior_layout_shift_toggle_data behavior_layout_shift_toggle_data_##n = {}; \
+    static const struct behavior_layout_shift_toggle_config behavior_layout_shift_toggle_config_##n = { \
+        .toggle_mode = TOGGLE_MODE_FROM_STR(DT_INST_PROP_OR(n, toggle_mode, "flip")), \
+    }; \
+    BEHAVIOR_DT_INST_DEFINE(n, layout_shift_toggle_init, NULL, \
+                            &behavior_layout_shift_toggle_data_##n, \
+                            &behavior_layout_shift_toggle_config_##n, \
+                            POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, \
+                            &behavior_layout_shift_toggle_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(LAYOUT_SHIFT_TOGGLE_INST)
+#endif

--- a/src/behavior_layout_shift_toggle.c
+++ b/src/behavior_layout_shift_toggle.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_layout_shift_toggle
 
 #include <zephyr/device.h>

--- a/src/behavior_momentary_layer_shift.c
+++ b/src/behavior_momentary_layer_shift.c
@@ -1,0 +1,104 @@
+#define DT_DRV_COMPAT zmk_behavior_mols
+
+#include "layouts/layout_common.h"
+#include <drivers/behavior.h>
+#include <stddef.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zmk/behavior.h>
+#include <zmk/keymap.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+// External function to check layout shift state
+extern bool zmk_layout_shift_is_active(void);
+
+struct layer_mapping {
+  uint8_t base_layer;
+  uint8_t shift_layer;
+};
+
+#define DEFINE_LAYER_MAPPING
+#include "layouts/index.h"
+#undef DEFINE_LAYER_MAPPING
+
+#ifdef LAYER_MAP_DEFINED
+#define LAYER_MAP_SIZE (sizeof(layer_map) / sizeof(layer_map[0]))
+#else
+#define LAYER_MAP_SIZE 0
+static const struct layer_mapping layer_map[0];
+#endif
+
+struct behavior_momentary_layer_shift_config {};
+
+struct behavior_momentary_layer_shift_data {
+  uint8_t active_layer;
+};
+
+static int mols_binding_pressed(struct zmk_behavior_binding *binding,
+                                struct zmk_behavior_binding_event event) {
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  struct behavior_momentary_layer_shift_data *data = dev->data;
+
+  uint8_t base_layer = binding->param1;
+  uint8_t target_layer = base_layer;
+
+  if (zmk_layout_shift_is_active()) {
+    for (size_t i = 0; i < LAYER_MAP_SIZE; i++) {
+      if (layer_map[i].base_layer == base_layer) {
+        target_layer = layer_map[i].shift_layer;
+        break;
+      }
+    }
+  }
+
+  data->active_layer = target_layer;
+  return zmk_keymap_layer_activate(target_layer);
+}
+
+static int mols_binding_released(struct zmk_behavior_binding *binding,
+                                 struct zmk_behavior_binding_event event) {
+  const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+  struct behavior_momentary_layer_shift_data *data = dev->data;
+
+  return zmk_keymap_layer_deactivate(data->active_layer);
+}
+
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+static const struct behavior_parameter_value_metadata param_values[] = {
+    {
+        .display_name = "Layer",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_LAYER_ID,
+    },
+};
+
+static const struct behavior_parameter_metadata_set param_metadata_set[] = {{
+    .param1_values = &param_values[0],
+    .param1_values_len = 1,
+}};
+
+static const struct behavior_parameter_metadata mols_parameter_metadata = {
+    .sets_len = ARRAY_SIZE(param_metadata_set),
+    .sets = param_metadata_set,
+};
+#endif
+
+static const struct behavior_driver_api
+    behavior_momentary_layer_shift_driver_api = {
+        .binding_pressed = mols_binding_pressed,
+        .binding_released = mols_binding_released,
+        .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+        .parameter_metadata = &mols_parameter_metadata,
+#endif
+};
+
+// Define behavior instances only if devicetree nodes exist
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define MOLS_INST(n)                                                           \
+  BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,              \
+                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                 \
+                          &behavior_momentary_layer_shift_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MOLS_INST)
+#endif

--- a/src/behavior_momentary_layer_shift.c
+++ b/src/behavior_momentary_layer_shift.c
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #define DT_DRV_COMPAT zmk_behavior_mols
 
 #include "layouts/layout_common.h"

--- a/src/behavior_momentary_layer_shift.c
+++ b/src/behavior_momentary_layer_shift.c
@@ -61,7 +61,9 @@ static int mols_binding_released(struct zmk_behavior_binding *binding,
   const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
   struct behavior_momentary_layer_shift_data *data = dev->data;
 
-  return zmk_keymap_layer_deactivate(data->active_layer);
+  uint8_t layer = data->active_layer;
+  data->active_layer = 0;
+  return zmk_keymap_layer_deactivate(layer);
 }
 
 #if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
@@ -96,8 +98,11 @@ static const struct behavior_driver_api
 // Define behavior instances only if devicetree nodes exist
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 #define MOLS_INST(n)                                                           \
-  BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,              \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                 \
+  static struct behavior_momentary_layer_shift_data                            \
+      behavior_momentary_layer_shift_data_##n = {};                            \
+  BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL,                                       \
+                          &behavior_momentary_layer_shift_data_##n, NULL,      \
+                          POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,    \
                           &behavior_momentary_layer_shift_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MOLS_INST)

--- a/src/layouts/index.h
+++ b/src/layouts/index.h
@@ -1,0 +1,11 @@
+// Layout index - includes all available layout definitions
+// Each layout file contains its own conditional compilation directives
+
+#include "layout_jis.h"
+#include "layout_dvorak.h"
+#include "layout_swap_ctrl_cmd.h"
+
+// Ensure at least one layout is defined
+#ifndef LAYOUT_DEFINED
+#error "No target layout selected. Please select a layout in Kconfig."
+#endif

--- a/src/layouts/index.h
+++ b/src/layouts/index.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 // Layout index - includes all available layout definitions
 // Each layout file contains its own conditional compilation directives
 

--- a/src/layouts/layout_common.h
+++ b/src/layouts/layout_common.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <dt-bindings/zmk/modifiers.h>
+#include <zmk/hid.h>
+#include <zmk/keys.h>
+
+struct keycode_mapping {
+  uint32_t us_keycode;
+  uint32_t target_keycode;
+  zmk_mod_flags_t optional_modifiers;
+};
+
+#define OPTIONAL_SHIFT (MOD_LSFT | MOD_RSFT)
+#define OPTIONAL_CTRL (MOD_LCTL | MOD_RCTL)
+#define OPTIONAL_ALT (MOD_LALT | MOD_RALT)
+#define OPTIONAL_GUI (MOD_LGUI | MOD_RGUI)
+#define OPTIONAL_ALL (0xFF)
+#define OPTIONAL_NONE (0)

--- a/src/layouts/layout_common.h
+++ b/src/layouts/layout_common.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #pragma once
 
 #include <dt-bindings/zmk/modifiers.h>

--- a/src/layouts/layout_common.h
+++ b/src/layouts/layout_common.h
@@ -10,6 +10,11 @@ struct keycode_mapping {
   zmk_mod_flags_t optional_modifiers;
 };
 
+struct msc_mapping {
+  uint32_t base;
+  uint32_t shifted;
+};
+
 #define OPTIONAL_SHIFT (MOD_LSFT | MOD_RSFT)
 #define OPTIONAL_CTRL (MOD_LCTL | MOD_RCTL)
 #define OPTIONAL_ALT (MOD_LALT | MOD_RALT)

--- a/src/layouts/layout_dvorak.h
+++ b/src/layouts/layout_dvorak.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_DVORAK
 #define LAYOUT_DEFINED
 // Dvorak keyboard layout mappings

--- a/src/layouts/layout_dvorak.h
+++ b/src/layouts/layout_dvorak.h
@@ -1,0 +1,42 @@
+#ifdef CONFIG_LAYOUT_SHIFT_TARGET_DVORAK
+#define LAYOUT_DEFINED
+// Dvorak keyboard layout mappings
+// Maps US QWERTY keycodes to their Dvorak equivalents
+static const struct keycode_mapping layout_map[] = {
+    /* Letter and symbol position changes (QWERTY -> Dvorak) */
+    /* For Dvorak, most modifiers are optional since it's primarily about key position changes */
+    {MINUS, LEFT_BRACKET, OPTIONAL_ALL},    // - -> [ (all modifiers optional)
+    {EQUAL, RIGHT_BRACKET, OPTIONAL_ALL},   // = -> ] (all modifiers optional)
+    {Q, SINGLE_QUOTE, OPTIONAL_ALL},        // Q -> ' (all modifiers optional)
+    {W, COMMA, OPTIONAL_ALL},               // W -> , (all modifiers optional)
+    {E, DOT, OPTIONAL_ALL},                 // E -> . (all modifiers optional)
+    {R, P, OPTIONAL_ALL},                   // R -> P (all modifiers optional)
+    {T, Y, OPTIONAL_ALL},                   // T -> Y (all modifiers optional)
+    {Y, F, OPTIONAL_ALL},                   // Y -> F (all modifiers optional)
+    {U, G, OPTIONAL_ALL},                   // U -> G (all modifiers optional)
+    {I, C, OPTIONAL_ALL},                   // I -> C (all modifiers optional)
+    {O, R, OPTIONAL_ALL},                   // O -> R (all modifiers optional)
+    {P, L, OPTIONAL_ALL},                   // P -> L (all modifiers optional)
+    {LEFT_BRACKET, SLASH, OPTIONAL_ALL},    // [ -> / (all modifiers optional)
+    {RIGHT_BRACKET, EQUAL, OPTIONAL_ALL},   // ] -> = (all modifiers optional)
+    {S, O, OPTIONAL_ALL},                   // S -> O (all modifiers optional)
+    {D, E, OPTIONAL_ALL},                   // D -> E (all modifiers optional)
+    {F, U, OPTIONAL_ALL},                   // F -> U (all modifiers optional)
+    {G, I, OPTIONAL_ALL},                   // G -> I (all modifiers optional)
+    {H, D, OPTIONAL_ALL},                   // H -> D (all modifiers optional)
+    {J, H, OPTIONAL_ALL},                   // J -> H (all modifiers optional)
+    {K, T, OPTIONAL_ALL},                   // K -> T (all modifiers optional)
+    {L, N, OPTIONAL_ALL},                   // L -> N (all modifiers optional)
+    {SEMICOLON, S, OPTIONAL_ALL},           // ; -> S (all modifiers optional)
+    {SINGLE_QUOTE, MINUS, OPTIONAL_ALL},    // ' -> - (all modifiers optional)
+    {Z, SEMICOLON, OPTIONAL_ALL},           // Z -> ; (all modifiers optional)
+    {X, Q, OPTIONAL_ALL},                   // X -> Q (all modifiers optional)
+    {C, J, OPTIONAL_ALL},                   // C -> J (all modifiers optional)
+    {V, K, OPTIONAL_ALL},                   // V -> K (all modifiers optional)
+    {B, X, OPTIONAL_ALL},                   // B -> X (all modifiers optional)
+    {N, B, OPTIONAL_ALL},                   // N -> B (all modifiers optional)
+    {COMMA, W, OPTIONAL_ALL},               // , -> W (all modifiers optional)
+    {DOT, V, OPTIONAL_ALL},                 // . -> V (all modifiers optional)
+    {SLASH, Z, OPTIONAL_ALL},               // / -> Z (all modifiers optional)
+};
+#endif

--- a/src/layouts/layout_jis.h
+++ b/src/layouts/layout_jis.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_JIS
 #define LAYOUT_DEFINED
 // Japanese (JIS) keyboard layout mappings

--- a/src/layouts/layout_jis.h
+++ b/src/layouts/layout_jis.h
@@ -1,0 +1,28 @@
+#ifdef CONFIG_LAYOUT_SHIFT_TARGET_JIS
+#define LAYOUT_DEFINED
+// Japanese (JIS) keyboard layout mappings
+// Maps US layout keycodes to their JIS equivalents
+static const struct keycode_mapping layout_map[] = {
+    /* from -> to, optional_modifiers */
+    {EQUAL,             UNDERSCORE,        OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* = -> _ (Ctrl/Alt/GUI optional) */
+    {CARET,             EQUAL,             OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ^ -> = (Ctrl/Alt/GUI optional) */
+    {TILDE,             PLUS,              OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ~ -> + (Ctrl/Alt/GUI optional) */
+    {AT_SIGN,           LEFT_BRACKET,      OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* @ -> [ (Ctrl/Alt/GUI optional) */
+    {GRAVE,             LEFT_BRACE,        OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ` -> { (Ctrl/Alt/GUI optional) */
+    {LEFT_BRACKET,      RIGHT_BRACKET,     OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* [ -> ] (Ctrl/Alt/GUI optional) */
+    {RIGHT_BRACKET,     BACKSLASH,         OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ] -> \ (Ctrl/Alt/GUI optional) */
+    {LEFT_BRACE,        RIGHT_BRACE,       OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* { -> } (Ctrl/Alt/GUI optional) */
+    {RIGHT_BRACE,       PIPE,              OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* } -> | (Ctrl/Alt/GUI optional) */
+    {PLUS,              COLON,             OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* + -> : (Ctrl/Alt/GUI optional) */
+    {COLON,             SINGLE_QUOTE,      OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* : -> ' (Ctrl/Alt/GUI optional) */
+    {ASTERISK,          DOUBLE_QUOTES,     OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* * -> " (Ctrl/Alt/GUI optional) */
+    {DOUBLE_QUOTES,     AT_SIGN,           OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* " -> @ (Ctrl/Alt/GUI optional) */
+    {AMPERSAND,         CARET,             OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* & -> ^ (Ctrl/Alt/GUI optional) */
+    {SINGLE_QUOTE,      AMPERSAND,         OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ' -> & (Ctrl/Alt/GUI optional) */
+    {LEFT_PARENTHESIS,  ASTERISK,          OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ( -> * (Ctrl/Alt/GUI optional) */
+    {RIGHT_PARENTHESIS, LEFT_PARENTHESIS,  OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* ) -> ( (Ctrl/Alt/GUI optional) */
+    {UNDERSCORE,        LS(0x87),          OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* _      (Ctrl/Alt/GUI optional) */
+    {BACKSLASH,         0x89,              OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* \      (Ctrl/Alt/GUI optional) */
+    {PIPE,              LS(0x89),          OPTIONAL_CTRL | OPTIONAL_ALT | OPTIONAL_GUI},  /* |      (Ctrl/Alt/GUI optional) */
+};
+#endif

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -1,5 +1,7 @@
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
 #define LAYOUT_DEFINED
+#include <dt-bindings/zmk/pointing.h>
+
 // Rotate modifier keys to match Mac/Windows layouts
 // Default (layout shift off): Mac layout (Ctrl-Opt-Cmd)
 // Layout shift on: rotate Cmd→Ctrl→Alt→Win→Cmd
@@ -14,6 +16,15 @@ static const struct keycode_mapping layout_map[] = {
     {RIGHT_ALT, RIGHT_GUI, OPTIONAL_ALL},         /* Alt -> Win */
     {RIGHT_GUI, RIGHT_COMMAND, OPTIONAL_ALL},     /* Win -> Cmd */
 };
+#ifdef DEFINE_MSC_MAPPING
+static const struct msc_mapping msc_map[] = {
+    {SCRL_UP, SCRL_DOWN},
+    {SCRL_DOWN, SCRL_UP},
+    {SCRL_LEFT, SCRL_RIGHT},
+    {SCRL_RIGHT, SCRL_LEFT},
+};
+#define MSC_MAP_DEFINED
+#endif
 #ifdef DEFINE_LAYER_MAPPING
 static const struct layer_mapping layer_map[] = {
     {5, 6}, /* Layer 5 -> Layer 6 when layout shift is active */

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -16,7 +16,7 @@ static const struct keycode_mapping layout_map[] = {
 };
 #ifdef DEFINE_LAYER_MAPPING
 static const struct layer_mapping layer_map[] = {
-    {6, 7}, /* Layer 6 -> Layer 7 when layout shift is active */
+    {5, 6}, /* Layer 5 -> Layer 6 when layout shift is active */
 };
 #define LAYER_MAP_DEFINED
 #endif

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -1,11 +1,17 @@
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
 #define LAYOUT_DEFINED
-// Swap Ctrl and Cmd
+// Rotate modifier keys to match Mac/Windows layouts
+// Default (layout shift off): Mac layout (Ctrl-Opt-Cmd)
+// Layout shift on: rotate Cmd→Ctrl→Alt→Win→Cmd
 static const struct keycode_mapping layout_map[] = {
     /* from -> to, optional_modifiers */
-    {LEFT_CONTROL,  LEFT_COMMAND,  OPTIONAL_ALL},
-    {LEFT_COMMAND,  LEFT_CONTROL,  OPTIONAL_ALL},
-    {RIGHT_CONTROL, RIGHT_COMMAND, OPTIONAL_ALL},
-    {RIGHT_COMMAND, RIGHT_CONTROL, OPTIONAL_ALL},
+    {LEFT_COMMAND,  LEFT_CONTROL, OPTIONAL_ALL},  /* Cmd -> Ctrl */
+    {LEFT_CONTROL,  LEFT_ALT,     OPTIONAL_ALL},  /* Ctrl -> Alt */
+    {LEFT_ALT,      LEFT_GUI,     OPTIONAL_ALL},  /* Alt -> Win */
+    {LEFT_GUI,      LEFT_COMMAND, OPTIONAL_ALL},  /* Win -> Cmd */
+    {RIGHT_COMMAND, RIGHT_CONTROL, OPTIONAL_ALL}, /* Cmd -> Ctrl */
+    {RIGHT_CONTROL, RIGHT_ALT,    OPTIONAL_ALL},  /* Ctrl -> Alt */
+    {RIGHT_ALT,     RIGHT_GUI,    OPTIONAL_ALL},  /* Alt -> Win */
+    {RIGHT_GUI,     RIGHT_COMMAND, OPTIONAL_ALL}, /* Win -> Cmd */
 };
 #endif

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -5,13 +5,19 @@
 // Layout shift on: rotate Cmd→Ctrl→Alt→Win→Cmd
 static const struct keycode_mapping layout_map[] = {
     /* from -> to, optional_modifiers */
-    {LEFT_COMMAND,  LEFT_CONTROL, OPTIONAL_ALL},  /* Cmd -> Ctrl */
-    {LEFT_CONTROL,  LEFT_ALT,     OPTIONAL_ALL},  /* Ctrl -> Alt */
-    {LEFT_ALT,      LEFT_GUI,     OPTIONAL_ALL},  /* Alt -> Win */
-    {LEFT_GUI,      LEFT_COMMAND, OPTIONAL_ALL},  /* Win -> Cmd */
+    {LEFT_COMMAND, LEFT_CONTROL, OPTIONAL_ALL},   /* Cmd -> Ctrl */
+    {LEFT_CONTROL, LEFT_ALT, OPTIONAL_ALL},       /* Ctrl -> Alt */
+    {LEFT_ALT, LEFT_GUI, OPTIONAL_ALL},           /* Alt -> Win */
+    {LEFT_GUI, LEFT_COMMAND, OPTIONAL_ALL},       /* Win -> Cmd */
     {RIGHT_COMMAND, RIGHT_CONTROL, OPTIONAL_ALL}, /* Cmd -> Ctrl */
-    {RIGHT_CONTROL, RIGHT_ALT,    OPTIONAL_ALL},  /* Ctrl -> Alt */
-    {RIGHT_ALT,     RIGHT_GUI,    OPTIONAL_ALL},  /* Alt -> Win */
-    {RIGHT_GUI,     RIGHT_COMMAND, OPTIONAL_ALL}, /* Win -> Cmd */
+    {RIGHT_CONTROL, RIGHT_ALT, OPTIONAL_ALL},     /* Ctrl -> Alt */
+    {RIGHT_ALT, RIGHT_GUI, OPTIONAL_ALL},         /* Alt -> Win */
+    {RIGHT_GUI, RIGHT_COMMAND, OPTIONAL_ALL},     /* Win -> Cmd */
 };
+#ifdef DEFINE_LAYER_MAPPING
+static const struct layer_mapping layer_map[] = {
+    {6, 7}, /* Layer 6 -> Layer 7 when layout shift is active */
+};
+#define LAYER_MAP_DEFINED
+#endif
 #endif

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -1,0 +1,11 @@
+#ifdef CONFIG_LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
+#define LAYOUT_DEFINED
+// Swap Ctrl and Cmd
+static const struct keycode_mapping layout_map[] = {
+    /* from -> to, optional_modifiers */
+    {LEFT_CONTROL,  LEFT_COMMAND,  OPTIONAL_ALL},
+    {LEFT_COMMAND,  LEFT_CONTROL,  OPTIONAL_ALL},
+    {RIGHT_CONTROL, RIGHT_COMMAND, OPTIONAL_ALL},
+    {RIGHT_COMMAND, RIGHT_CONTROL, OPTIONAL_ALL},
+};
+#endif

--- a/src/layouts/layout_swap_ctrl_cmd.h
+++ b/src/layouts/layout_swap_ctrl_cmd.h
@@ -1,3 +1,11 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
 #ifdef CONFIG_LAYOUT_SHIFT_TARGET_SWAP_CTRL_CMD
 #define LAYOUT_DEFINED
 #include <dt-bindings/zmk/pointing.h>

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,6 @@
 build:
+  cmake: .
+  kconfig: Kconfig
   settings:
     board_root: .
+    dts_root: .


### PR DESCRIPTION
- レイヤーシフトすることにより装飾キーをwindows用にバインドする機能を追加
- スクロールの向きをMacとWinでそれぞれ同じになるようにレイヤーシフトする機能を追加(&mscls,&mols)
- レイアウトシフトを明示的に設定する &to_ls を追加