### PR TITLE
レイアウト環境ビヘイビアのバインディングを追加

### DIFF
--- a/dts/bindings/behaviors/zmk,behavior-layout-env-key-press.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-env-key-press.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout environment aware key press behavior
+
+compatible: "zmk,behavior-layout-env-key-press"
+
+include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-layout-env-to.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-env-to.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout environment set behavior
+
+compatible: "zmk,behavior-layout-env-to"
+
+include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-layout-env-toggle.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-env-toggle.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout environment toggle behavior
+
+compatible: "zmk,behavior-layout-env-toggle"
+
+include: zero_param.yaml
+
+properties:
+  toggle-mode:
+    type: string
+    required: false
+    default: "flip"
+    enum:
+      - "on"
+      - "off"
+      - "flip"
+    description: |
+      Toggle mode for the layout environment behavior:
+      - "on": Enable layout environment
+      - "off": Disable layout environment
+      - "flip": Toggle layout environment state


### PR DESCRIPTION
## 概要
- レイアウト環境関連ビヘイビアのバインディングを新規追加

## テスト
- `west build -s zmk/app -b akdk_bt1 -d build/left -- -DZMK_CONFIG=$(pwd)/config -DSHIELD=surround1x0_akdk_left -DZMK_EXTRA_MODULES=$(pwd)`  (Zephyr SDK が見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_e_68b3fe00d374832cafe4b1bb2b9c9e90